### PR TITLE
open 時にプロジェクト environments を tmux セッションへ適用

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -446,7 +446,8 @@ class ProjectConfig:
 ### 適用方式
 
 - **方式**: `tmux set-environment -t <session> KEY VALUE`（セッションスコープ）
-- **タイミング**: `itmux open` のたびに適用（新規作成・既存 attach 双方）。`itmux add` 時も再適用
+- **タイミング**: `itmux open` のたびに適用（新規作成・既存 attach 双方）。`itmux add` 時はウィンドウ作成**前**に再適用
+- **新規セッション**: 一時ウィンドウ（`_itmux_bootstrap`）でセッションだけ作成 → `set-environment` → 初回ウィンドウ作成 → 一時ウィンドウ削除（シェル起動前に env を設定）
 - **未指定時**: `environments` 省略または空 dict → 何も変更しない（後方互換）
 - **新規ペイン**: セッション環境変数を継承するため、`echo $KEY` で即確認可能
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,11 +133,19 @@ set-environment -g PATH "/opt/homebrew/bin:$PATH"
    - グローバルのsession-closed: 上書き
    - 何回openしても多重登録されない（冪等性）
 
-7. 完了
+7. プロジェクト環境変数を適用
+   tmux set-environment -t <project> KEY VALUE
+
+   - config.json の environments をセッションスコープで設定
+   - 新規ペイン・新規ウィンドウのシェルに継承される
+   - 既存 attach / resurrect 復元後も毎回 open で再適用
+
+8. 完了
    → iTerm2に必要なウィンドウだけが開く
    → 既に開いているウィンドウはそのまま
    → 各ウィンドウに user.projectID, user.window_name タグ
    → tmux hookによる自動同期が有効化
+   → config の environments が tmux セッションに適用される
    → tmux session内では session名からプロジェクト名を自動検出
 ```
 
@@ -384,7 +392,11 @@ $ itmux close         # webappを閉じる
             "lines": 40
           }
         }
-      ]
+      ],
+      "environments": {
+        "NODE_ENV": "development",
+        "MY_VAR": "value"
+      }
     }
   }
 }
@@ -407,7 +419,57 @@ class SessionConfig:
 class ProjectConfig:
     name: str
     sessions: list[SessionConfig]
+    environments: dict[str, str]  # 省略時は {}
 ```
+
+## プロジェクト環境変数
+
+### 概要
+
+プロジェクトごとに `environments` を `config.json` で定義し、`itmux open` 時に tmux セッションスコープへ適用します。
+
+```json
+{
+  "projects": {
+    "my-project": {
+      "name": "my-project",
+      "environments": {
+        "NODE_ENV": "development",
+        "FOO": "bar"
+      },
+      "tmux_windows": [...]
+    }
+  }
+}
+```
+
+### 適用方式
+
+- **方式**: `tmux set-environment -t <session> KEY VALUE`（セッションスコープ）
+- **タイミング**: `itmux open` のたびに適用（新規作成・既存 attach 双方）。`itmux add` 時も再適用
+- **未指定時**: `environments` 省略または空 dict → 何も変更しない（後方互換）
+- **新規ペイン**: セッション環境変数を継承するため、`echo $KEY` で即確認可能
+
+### tmux-resurrect との整合
+
+tmux-resurrect はセッション環境変数も保存・復元します。競合時の正本は **config.json の `environments`** です。
+
+| タイミング | 動作 |
+|-----------|------|
+| resurrect 復元直後 | 保存時点の環境変数が復元される |
+| `itmux open` 実行後 | config の `environments` で上書き |
+| 新規ウィンドウ / ペイン | 上書き後の値が継承される |
+
+**既存ペインのシェル**は tmux の仕様上、`set-environment` だけでは更新されません。復元直後に開いていたシェルで値を反映したい場合は、シェルを再起動するか、シェル設定で以下を利用してください。
+
+```bash
+# ~/.zshrc 等（tmux 内でのみ実行）
+if [ -n "$TMUX" ]; then
+  eval "$(tmux show-environment -s)"
+fi
+```
+
+推奨フロー: システム再起動 → tmux-resurrect で復元 → `itmux open <project>` で iTerm2 ウィンドウを開く。
 
 ## iTerm2 Python API統合
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -261,7 +261,7 @@ itmux open my-project
 
 ```bash
 itmux close my-project
-# または、環境変数を使って省略形
+# または、tmux セッション内ではプロジェクト名を省略
 itmux close
 ```
 
@@ -271,7 +271,6 @@ itmux close
 3. 各ウィンドウをデタッチ
 4. iTerm2のウィンドウは閉じる
 5. tmuxセッションはバックグラウンドで継続
-6. 環境変数 `ITMUX_PROJECT` をクリア
 
 **重要**: プロセスは停止しません
 - nvimで編集中のファイルはそのまま
@@ -313,9 +312,9 @@ itmux add my-project my_monitoring
 itmux add my-project
 # → 自動的に my-project-1, my-project-2 などが割り当てられる
 
-# パターン3: 環境変数を使って省略
+# パターン3: tmux セッション内で実行（プロジェクト名を自動検出）
 itmux add
-# → $ITMUX_PROJECT に新しいセッションを追加
+# → 現在の tmux session 名（= プロジェクト名）に新しいセッションを追加
 ```
 
 **動作**:
@@ -328,11 +327,10 @@ itmux add
 ```bash
 # プロジェクトを開いた状態で
 itmux open webapp
-# → 環境変数 ITMUX_PROJECT=webapp が設定される
 
-# 作業中に新しいウィンドウが必要になった
+# 作業中に新しいウィンドウが必要になった（tmux session 内で実行）
 itmux add monitoring
-# → webappプロジェクトに monitoring セッションを追加
+# → webapp プロジェクトに monitoring セッションを追加
 
 # プロジェクトを閉じる
 itmux close
@@ -454,6 +452,38 @@ Projects:
 
 省略した場合、デフォルトサイズで開きます。
 
+### プロジェクト環境変数（environments）
+
+プロジェクトごとにシェル環境変数を定義できます。`itmux open` 時に tmux セッションスコープへ適用され、新規ペインのシェルで利用できます。
+
+```json
+{
+  "projects": {
+    "my-project": {
+      "name": "my-project",
+      "environments": {
+        "NODE_ENV": "development",
+        "FOO": "bar"
+      },
+      "tmux_windows": [
+        {"name": "editor"}
+      ]
+    }
+  }
+}
+```
+
+```bash
+itmux open my-project
+# 新規ウィンドウのシェルで確認
+echo $NODE_ENV  # → development
+```
+
+**注意**:
+- `environments` 未指定時は従来どおり（後方互換）
+- tmux-resurrect 復元後は `itmux open` で config の値が再適用される
+- 復元直後から存在していたシェルは tmux の仕様上、再起動するまで値が変わらない場合がある
+
 ### 複数プロジェクト
 
 ```json
@@ -509,7 +539,6 @@ Projects:
 ```bash
 # 朝、仕事開始
 itmux open webapp
-# → 環境変数 ITMUX_PROJECT=webapp が設定される
 
 # [webapp_editor ウィンドウ]
 cd ~/work/webapp
@@ -539,7 +568,6 @@ itmux close
 # → 全てのウィンドウが閉じる（monitoring含む）
 # → サーバーは動き続ける
 # → config.jsonに現在の状態が自動保存される
-# → 環境変数 ITMUX_PROJECT がクリアされる
 
 # 翌朝、再開
 itmux open webapp
@@ -553,13 +581,11 @@ itmux open webapp
 ```bash
 # プロジェクトAで作業
 itmux open project-a
-# → ITMUX_PROJECT=project-a
 # ... 作業 ...
 
 # プロジェクトBに切り替え
 itmux close          # project-aを自動保存して閉じる
 itmux open project-b
-# → ITMUX_PROJECT=project-b
 # ... 作業 ...
 
 # プロジェクトAに戻る

--- a/src/itmux/iterm2/bridge.py
+++ b/src/itmux/iterm2/bridge.py
@@ -66,24 +66,34 @@ class ITerm2Bridge:
         cmd = f"tmux resize-window -x {window_size.columns} -y {window_size.lines}\n"
         await session.async_send_text(cmd)
 
-    async def connect_to_session(self, project_name: str, first_window_name: str = "default") -> None:
+    async def connect_to_session(
+        self,
+        project_name: str,
+        first_window_name: str = "default",
+        environments: Optional[dict[str, str]] = None,
+    ) -> None:
         """tmux Control Modeセッションに接続.
 
         Args:
             project_name: プロジェクト名
             first_window_name: 最初のウィンドウ名
+            environments: 適用するセッション環境変数
 
         Raises:
             ITerm2Error: 接続に失敗
         """
         try:
-            # Control Modeでtmuxセッションに接続
-            # -A: セッションが存在しない場合は作成、存在する場合はアタッチ
-            # -s: セッション名
-            # -n: 最初のウィンドウ名
+            from ..tmux.environment import prepare_session_environments
+
+            # シェル起動前にセッション環境変数を整える
+            prepare_session_environments(
+                project_name, environments or {}, first_window_name
+            )
+
+            # Control Modeで既存セッションにアタッチ
             gateway = await iterm2.Window.async_create(
                 self.connection,
-                command=f"/opt/homebrew/bin/tmux -CC new-session -A -s {project_name} -n {first_window_name}"
+                command=f"/opt/homebrew/bin/tmux -CC attach-session -t {project_name}"
             )
 
             if not gateway:
@@ -298,6 +308,7 @@ class ITerm2Bridge:
         self,
         project_name: str,
         window_configs: list[WindowConfig],
+        environments: Optional[dict[str, str]] = None,
     ) -> list[str]:
         """プロジェクトのtmuxウィンドウを開く.
 
@@ -307,6 +318,7 @@ class ITerm2Bridge:
         Args:
             project_name: プロジェクト名
             window_configs: ウィンドウ設定のリスト（空の場合は default を作成）
+            environments: セッション環境変数（シェル起動前に適用）
 
         Returns:
             list[str]: 新規作成されたiTerm2ウィンドウIDのリスト
@@ -319,8 +331,10 @@ class ITerm2Bridge:
             if not window_configs:
                 window_configs = [WindowConfig(name="default")]
 
-            # 2. セッションに接続（最初のウィンドウ名を指定）
-            await self.connect_to_session(project_name, window_configs[0].name)
+            # 2. セッションに接続（環境変数は connect 前に適用）
+            await self.connect_to_session(
+                project_name, window_configs[0].name, environments=environments
+            )
 
             # 3. TmuxConnection を取得
             tmux_conn = await self.get_tmux_connection(project_name)

--- a/src/itmux/models.py
+++ b/src/itmux/models.py
@@ -1,7 +1,7 @@
 """iTmux data models using Pydantic."""
 
-from typing import Optional
-from pydantic import BaseModel, Field, field_validator
+from typing import Optional, Any
+from pydantic import BaseModel, Field, field_validator, model_serializer
 
 
 class WindowSize(BaseModel):
@@ -44,6 +44,9 @@ class ProjectConfig(BaseModel):
 
     name: str = Field(min_length=1, description="プロジェクト名")
     description: Optional[str] = Field(default=None, description="プロジェクトの説明")
+    environments: dict[str, str] = Field(
+        default_factory=dict, description="セッションスコープの環境変数"
+    )
     tmux_windows: list[WindowConfig] = Field(
         default_factory=list, description="tmuxウィンドウリスト"
     )
@@ -58,6 +61,27 @@ class ProjectConfig(BaseModel):
             if char in v:
                 raise ValueError(f'project name cannot contain "{char}"')
         return v
+
+    @field_validator("environments")
+    @classmethod
+    def validate_environments(cls, v: dict[str, str]) -> dict[str, str]:
+        """環境変数名の最小バリデーション."""
+        for key in v:
+            if not key:
+                raise ValueError("environment variable name cannot be empty")
+            if not key.replace("_", "").isalnum():
+                raise ValueError(
+                    f'environment variable name "{key}" contains invalid characters'
+                )
+        return v
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, serializer: Any) -> dict[str, Any]:
+        """空の environments は JSON 出力から除外（後方互換）."""
+        data = serializer(self)
+        if not data.get("environments"):
+            data.pop("environments", None)
+        return data
 
     @field_validator("tmux_windows")
     @classmethod

--- a/src/itmux/orchestrator.py
+++ b/src/itmux/orchestrator.py
@@ -333,12 +333,14 @@ class ProjectOrchestrator:
 
         # windows_to_openが空でも、プロジェクトのウィンドウが0個かつcreate_default=Trueなら開く
         if windows_to_open or (not project.tmux_windows and create_default):
-            await self.bridge.open_project_windows(project_name, windows_to_open)
+            await self.bridge.open_project_windows(
+                project_name, windows_to_open, project.environments
+            )
+        elif project.environments:
+            # 全ウィンドウが既に開いている場合（resurrect 後の再適用など）
+            apply_session_environments(project_name, project.environments)
 
-        # 4. プロジェクト環境変数をtmuxセッションに適用
-        apply_session_environments(project_name, project.environments)
-
-        # 5. hookを設定（自動同期を有効化）
+        # 4. hookを設定（自動同期を有効化）
         # セッションスコープのhook（after-new-window等）は上書きされるため、
         # グローバルのsession-closedも上書きされるため、何回openしても多重登録されない
         itmux_command = os.environ.get("ITMUX_COMMAND", "itmux")
@@ -524,14 +526,12 @@ class ProjectOrchestrator:
         if window_name is None:
             window_name = self._generate_window_name(project_name)
 
-        # 3. 新規ウィンドウ作成
-        await self.bridge.add_window(project_name, window_name)
-
-        # 4. 環境変数を再適用（新規ペインがセッション env を継承する）
+        # 3. 環境変数を適用してから新規ウィンドウ作成
         project = self.config.get_project(project_name)
         apply_session_environments(project_name, project.environments)
+        await self.bridge.add_window(project_name, window_name)
 
-        # 5. 状態を同期（hookも実行されるが、確実性のため明示的に呼ぶ）
+        # 4. 状態を同期（hookも実行されるが、確実性のため明示的に呼ぶ）
         # after-new-window hookが発火するが、タイミングによっては
         # user.window_name設定前にsyncが実行される可能性があるため、
         # tag_window()完了後に明示的にsyncを実行する

--- a/src/itmux/orchestrator.py
+++ b/src/itmux/orchestrator.py
@@ -9,6 +9,7 @@ from .config import ConfigManager
 from .iterm2 import ITerm2Bridge
 from .models import WindowConfig
 from .exceptions import ProjectNotFoundError
+from .tmux.environment import apply_session_environments
 
 
 class ProjectOrchestrator:
@@ -334,7 +335,10 @@ class ProjectOrchestrator:
         if windows_to_open or (not project.tmux_windows and create_default):
             await self.bridge.open_project_windows(project_name, windows_to_open)
 
-        # 4. hookを設定（自動同期を有効化）
+        # 4. プロジェクト環境変数をtmuxセッションに適用
+        apply_session_environments(project_name, project.environments)
+
+        # 5. hookを設定（自動同期を有効化）
         # セッションスコープのhook（after-new-window等）は上書きされるため、
         # グローバルのsession-closedも上書きされるため、何回openしても多重登録されない
         itmux_command = os.environ.get("ITMUX_COMMAND", "itmux")
@@ -523,7 +527,11 @@ class ProjectOrchestrator:
         # 3. 新規ウィンドウ作成
         await self.bridge.add_window(project_name, window_name)
 
-        # 4. 状態を同期（hookも実行されるが、確実性のため明示的に呼ぶ）
+        # 4. 環境変数を再適用（新規ペインがセッション env を継承する）
+        project = self.config.get_project(project_name)
+        apply_session_environments(project_name, project.environments)
+
+        # 5. 状態を同期（hookも実行されるが、確実性のため明示的に呼ぶ）
         # after-new-window hookが発火するが、タイミングによっては
         # user.window_name設定前にsyncが実行される可能性があるため、
         # tag_window()完了後に明示的にsyncを実行する

--- a/src/itmux/tmux/__init__.py
+++ b/src/itmux/tmux/__init__.py
@@ -2,6 +2,12 @@
 
 from .session_manager import SessionManager
 from .hook_manager import HookManager
-from .environment import apply_session_environments, tmux_has_session
+from .environment import apply_session_environments, tmux_has_session, prepare_session_environments
 
-__all__ = ["SessionManager", "HookManager", "apply_session_environments", "tmux_has_session"]
+__all__ = [
+    "SessionManager",
+    "HookManager",
+    "apply_session_environments",
+    "tmux_has_session",
+    "prepare_session_environments",
+]

--- a/src/itmux/tmux/__init__.py
+++ b/src/itmux/tmux/__init__.py
@@ -2,5 +2,6 @@
 
 from .session_manager import SessionManager
 from .hook_manager import HookManager
+from .environment import apply_session_environments, tmux_has_session
 
-__all__ = ["SessionManager", "HookManager"]
+__all__ = ["SessionManager", "HookManager", "apply_session_environments", "tmux_has_session"]

--- a/src/itmux/tmux/environment.py
+++ b/src/itmux/tmux/environment.py
@@ -4,6 +4,9 @@ import os
 import subprocess
 from typing import Optional
 
+# 環境変数適用前の一時ウィンドウ名（ユーザー向けシェルは起動しない）
+BOOTSTRAP_WINDOW = "_itmux_bootstrap"
+
 
 def tmux_has_session(session_name: str, env: Optional[dict[str, str]] = None) -> bool:
     """tmuxセッションが存在するか確認."""
@@ -44,4 +47,83 @@ def apply_session_environments(
             check=False,
             env=run_env,
         )
+    return True
+
+
+def prepare_session_environments(
+    session_name: str,
+    environments: dict[str, str],
+    first_window_name: str,
+    env: Optional[dict[str, str]] = None,
+) -> bool:
+    """シェル起動前にセッション環境変数を整える.
+
+    新規セッションかつ environments がある場合は、一時ウィンドウで
+    セッションだけ作成してから set-environment し、初回ウィンドウを作る。
+
+    Args:
+        session_name: tmuxセッション名
+        environments: 適用する環境変数
+        first_window_name: 初回ウィンドウ名
+        env: subprocess に渡す環境変数
+
+    Returns:
+        bool: 新規セッションを作成した場合 True
+    """
+    run_env = (env or os.environ).copy()
+
+    if tmux_has_session(session_name, env=run_env):
+        apply_session_environments(session_name, environments, env=run_env)
+        return False
+
+    if environments:
+        subprocess.run(
+            [
+                "tmux",
+                "new-session",
+                "-d",
+                "-s",
+                session_name,
+                "-n",
+                BOOTSTRAP_WINDOW,
+            ],
+            capture_output=True,
+            check=False,
+            env=run_env,
+        )
+        apply_session_environments(session_name, environments, env=run_env)
+        if first_window_name != BOOTSTRAP_WINDOW:
+            subprocess.run(
+                ["tmux", "new-window", "-t", session_name, "-n", first_window_name],
+                capture_output=True,
+                check=False,
+                env=run_env,
+            )
+            subprocess.run(
+                [
+                    "tmux",
+                    "kill-window",
+                    "-t",
+                    f"{session_name}:{BOOTSTRAP_WINDOW}",
+                ],
+                capture_output=True,
+                check=False,
+                env=run_env,
+            )
+    else:
+        subprocess.run(
+            [
+                "tmux",
+                "new-session",
+                "-d",
+                "-s",
+                session_name,
+                "-n",
+                first_window_name,
+            ],
+            capture_output=True,
+            check=False,
+            env=run_env,
+        )
+
     return True

--- a/src/itmux/tmux/environment.py
+++ b/src/itmux/tmux/environment.py
@@ -1,0 +1,47 @@
+"""tmuxセッションへの環境変数適用."""
+
+import os
+import subprocess
+from typing import Optional
+
+
+def tmux_has_session(session_name: str, env: Optional[dict[str, str]] = None) -> bool:
+    """tmuxセッションが存在するか確認."""
+    result = subprocess.run(
+        ["tmux", "has-session", "-t", session_name],
+        capture_output=True,
+        env=(env or os.environ).copy(),
+    )
+    return result.returncode == 0
+
+
+def apply_session_environments(
+    session_name: str,
+    environments: dict[str, str],
+    env: Optional[dict[str, str]] = None,
+) -> bool:
+    """tmuxセッションスコープの環境変数を適用.
+
+    Args:
+        session_name: tmuxセッション名（= プロジェクト名）
+        environments: 適用する環境変数
+        env: subprocess に渡す環境変数（省略時は os.environ）
+
+    Returns:
+        bool: 適用を試みた場合 True、スキップした場合 False
+    """
+    if not environments:
+        return False
+
+    if not tmux_has_session(session_name, env=env):
+        return False
+
+    run_env = (env or os.environ).copy()
+    for key, value in environments.items():
+        subprocess.run(
+            ["tmux", "set-environment", "-t", session_name, key, value],
+            capture_output=True,
+            check=False,
+            env=run_env,
+        )
+    return True

--- a/tests/itmux/test_environment.py
+++ b/tests/itmux/test_environment.py
@@ -1,9 +1,15 @@
 """tests/itmux/test_environment.py - tmux環境変数適用のテスト."""
 
 import os
+import pytest
 from unittest.mock import MagicMock, patch
 
-from itmux.tmux.environment import apply_session_environments, tmux_has_session
+from itmux.tmux.environment import (
+    BOOTSTRAP_WINDOW,
+    apply_session_environments,
+    prepare_session_environments,
+    tmux_has_session,
+)
 
 
 class TestTmuxHasSession:
@@ -78,3 +84,112 @@ class TestApplySessionEnvironments:
 
         assert result is False
         mock_run.assert_not_called()
+
+
+class TestPrepareSessionEnvironments:
+    """prepare_session_environments()のテスト."""
+
+    @patch("itmux.tmux.environment.apply_session_environments")
+    @patch("itmux.tmux.environment.tmux_has_session")
+    @patch("itmux.tmux.environment.subprocess.run")
+    def test_new_session_applies_env_before_first_window(
+        self, mock_run, mock_has_session, mock_apply
+    ):
+        """新規セッションでは set-environment 後に初回ウィンドウを作成."""
+        mock_has_session.return_value = False
+
+        created = prepare_session_environments(
+            "my-project",
+            {"MY_KEY": "my_value"},
+            "editor",
+        )
+
+        assert created is True
+        mock_apply.assert_called_once()
+        calls = [c.args[0] for c in mock_run.call_args_list]
+        assert calls[0][:4] == ["tmux", "new-session", "-d", "-s"]
+        assert calls[0][6] == BOOTSTRAP_WINDOW
+        assert calls[1][:3] == ["tmux", "new-window", "-t"]
+        assert calls[1][4:6] == ["-n", "editor"]
+        assert calls[2][:3] == ["tmux", "kill-window", "-t"]
+
+    @patch("itmux.tmux.environment.apply_session_environments")
+    @patch("itmux.tmux.environment.tmux_has_session")
+    @patch("itmux.tmux.environment.subprocess.run")
+    def test_existing_session_only_applies_env(
+        self, mock_run, mock_has_session, mock_apply
+    ):
+        """既存セッションでは環境変数の再適用のみ."""
+        mock_has_session.return_value = True
+
+        created = prepare_session_environments(
+            "my-project",
+            {"MY_KEY": "my_value"},
+            "editor",
+        )
+
+        assert created is False
+        mock_apply.assert_called_once_with(
+            "my-project", {"MY_KEY": "my_value"}, env=os.environ.copy()
+        )
+        mock_run.assert_not_called()
+
+    @patch("itmux.tmux.environment.tmux_has_session")
+    @patch("itmux.tmux.environment.subprocess.run")
+    def test_new_session_without_environments(
+        self, mock_run, mock_has_session
+    ):
+        """environments なしの新規セッションは通常作成."""
+        mock_has_session.return_value = False
+
+        created = prepare_session_environments("my-project", {}, "editor")
+
+        assert created is True
+        mock_run.assert_called_once_with(
+            ["tmux", "new-session", "-d", "-s", "my-project", "-n", "editor"],
+            capture_output=True,
+            check=False,
+            env=os.environ.copy(),
+        )
+
+
+class TestPrepareSessionEnvironmentsIntegration:
+    """prepare_session_environments() の tmux 実機検証."""
+
+    @pytest.fixture(autouse=True)
+    def require_tmux(self):
+        import shutil
+        if shutil.which("tmux") is None:
+            pytest.skip("tmux not available")
+
+    def test_session_environment_is_set_before_shell(self):
+        """set-environment が初回ウィンドウ作成前にセッションへ設定される."""
+        import subprocess
+
+        session = "itmux-test-env-integration"
+        subprocess.run(
+            ["tmux", "kill-session", "-t", session],
+            capture_output=True,
+            check=False,
+        )
+
+        prepare_session_environments(
+            session,
+            {"MY_KEY": "my_value"},
+            "editor",
+        )
+
+        result = subprocess.run(
+            ["tmux", "show-environment", "-t", session, "MY_KEY"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        subprocess.run(
+            ["tmux", "kill-session", "-t", session],
+            capture_output=True,
+            check=False,
+        )
+
+        assert "my_value" in result.stdout
+

--- a/tests/itmux/test_environment.py
+++ b/tests/itmux/test_environment.py
@@ -1,0 +1,80 @@
+"""tests/itmux/test_environment.py - tmux環境変数適用のテスト."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from itmux.tmux.environment import apply_session_environments, tmux_has_session
+
+
+class TestTmuxHasSession:
+    """tmux_has_session()のテスト."""
+
+    @patch("itmux.tmux.environment.subprocess.run")
+    def test_session_exists(self, mock_run):
+        """セッションが存在する場合True."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        assert tmux_has_session("my-project") is True
+        mock_run.assert_called_once_with(
+            ["tmux", "has-session", "-t", "my-project"],
+            capture_output=True,
+            env=os.environ.copy(),
+        )
+
+    @patch("itmux.tmux.environment.subprocess.run")
+    def test_session_not_exists(self, mock_run):
+        """セッションが存在しない場合False."""
+        mock_run.return_value = MagicMock(returncode=1)
+
+        assert tmux_has_session("missing") is False
+
+
+class TestApplySessionEnvironments:
+    """apply_session_environments()のテスト."""
+
+    @patch("itmux.tmux.environment.tmux_has_session")
+    @patch("itmux.tmux.environment.subprocess.run")
+    def test_apply_all_variables(self, mock_run, mock_has_session):
+        """各環境変数に対して set-environment を実行."""
+        mock_has_session.return_value = True
+
+        result = apply_session_environments(
+            "my-project",
+            {"NODE_ENV": "development", "FOO": "bar"},
+        )
+
+        assert result is True
+        assert mock_run.call_count == 2
+        mock_run.assert_any_call(
+            ["tmux", "set-environment", "-t", "my-project", "NODE_ENV", "development"],
+            capture_output=True,
+            check=False,
+            env=os.environ.copy(),
+        )
+        mock_run.assert_any_call(
+            ["tmux", "set-environment", "-t", "my-project", "FOO", "bar"],
+            capture_output=True,
+            check=False,
+            env=os.environ.copy(),
+        )
+
+    @patch("itmux.tmux.environment.tmux_has_session")
+    @patch("itmux.tmux.environment.subprocess.run")
+    def test_empty_environments_skipped(self, mock_run, mock_has_session):
+        """空の environments は何もしない."""
+        result = apply_session_environments("my-project", {})
+
+        assert result is False
+        mock_has_session.assert_not_called()
+        mock_run.assert_not_called()
+
+    @patch("itmux.tmux.environment.tmux_has_session")
+    @patch("itmux.tmux.environment.subprocess.run")
+    def test_session_not_found_skipped(self, mock_run, mock_has_session):
+        """セッションが存在しない場合はスキップ."""
+        mock_has_session.return_value = False
+
+        result = apply_session_environments("my-project", {"FOO": "bar"})
+
+        assert result is False
+        mock_run.assert_not_called()

--- a/tests/itmux/test_models.py
+++ b/tests/itmux/test_models.py
@@ -148,6 +148,38 @@ class TestProjectConfig:
         project = ProjectConfig(name="my-project")
         assert project.description is None
 
+    def test_project_with_environments(self):
+        """環境変数付きプロジェクト."""
+        project = ProjectConfig(
+            name="my-project",
+            environments={"NODE_ENV": "development", "FOO": "bar"},
+        )
+        assert project.environments == {"NODE_ENV": "development", "FOO": "bar"}
+
+    def test_project_without_environments_defaults_empty(self):
+        """environments 未指定は空 dict."""
+        project = ProjectConfig(name="my-project")
+        assert project.environments == {}
+
+    def test_invalid_environment_name_raises_error(self):
+        """不正な環境変数名はエラー."""
+        with pytest.raises(ValidationError):
+            ProjectConfig(name="my-project", environments={"INVALID-KEY": "value"})
+
+    def test_empty_environment_name_raises_error(self):
+        """空の環境変数名はエラー."""
+        with pytest.raises(ValidationError):
+            ProjectConfig(name="my-project", environments={"": "value"})
+
+    def test_backward_compatible_json_without_environments(self):
+        """environments なしの既存 config が読み込める."""
+        data = {
+            "name": "legacy-project",
+            "tmux_windows": [{"name": "main"}],
+        }
+        project = ProjectConfig.model_validate(data)
+        assert project.environments == {}
+
     def test_json_serialization(self):
         """JSON変換."""
         project = ProjectConfig(

--- a/tests/itmux/test_orchestrator.py
+++ b/tests/itmux/test_orchestrator.py
@@ -149,7 +149,7 @@ class TestOpen:
 
         # open_project_windowsが呼ばれる
         mock_iterm2_bridge.open_project_windows.assert_called_once_with(
-            "test-project", windows
+            "test-project", windows, {}
         )
 
     @pytest.mark.asyncio
@@ -168,7 +168,7 @@ class TestOpen:
 
         # open_project_windowsが呼ばれる
         mock_iterm2_bridge.open_project_windows.assert_called_once_with(
-            "test-project", windows
+            "test-project", windows, {}
         )
 
     @pytest.mark.asyncio
@@ -188,7 +188,7 @@ class TestOpen:
 
         # open_project_windowsが呼ばれる（ウィンドウサイズはWindowConfig内に含まれる）
         mock_iterm2_bridge.open_project_windows.assert_called_once_with(
-            "test-project", windows
+            "test-project", windows, {}
         )
 
     @pytest.mark.asyncio
@@ -216,13 +216,12 @@ class TestOpen:
         mock_config_manager.create_project.assert_called_once_with("nonexistent", windows=[])
 
     @pytest.mark.asyncio
-    @patch("itmux.orchestrator.apply_session_environments")
     @patch('itmux.orchestrator.ProjectOrchestrator._is_tmux_running')
-    async def test_open_applies_environments(
-        self, mock_is_tmux_running, mock_apply_env,
+    async def test_open_passes_environments_to_bridge(
+        self, mock_is_tmux_running,
         mock_config_manager, mock_iterm2_bridge, mock_environ
     ):
-        """open 時に environments を tmux セッションへ適用."""
+        """open 時に environments を bridge へ渡す（シェル起動前適用）."""
         mock_is_tmux_running.return_value = True
         mock_config_manager.get_project.return_value = ProjectConfig(
             name="test-project",
@@ -233,8 +232,10 @@ class TestOpen:
         orchestrator = ProjectOrchestrator(mock_config_manager, mock_iterm2_bridge)
         await orchestrator.open("test-project")
 
-        mock_apply_env.assert_called_once_with(
-            "test-project", {"MY_KEY": "my_value"}
+        mock_iterm2_bridge.open_project_windows.assert_called_once_with(
+            "test-project",
+            [WindowConfig(name="editor")],
+            {"MY_KEY": "my_value"},
         )
 
     @pytest.mark.asyncio

--- a/tests/itmux/test_orchestrator.py
+++ b/tests/itmux/test_orchestrator.py
@@ -214,3 +214,49 @@ class TestOpen:
 
         # create_projectが呼ばれたことを確認
         mock_config_manager.create_project.assert_called_once_with("nonexistent", windows=[])
+
+    @pytest.mark.asyncio
+    @patch("itmux.orchestrator.apply_session_environments")
+    @patch('itmux.orchestrator.ProjectOrchestrator._is_tmux_running')
+    async def test_open_applies_environments(
+        self, mock_is_tmux_running, mock_apply_env,
+        mock_config_manager, mock_iterm2_bridge, mock_environ
+    ):
+        """open 時に environments を tmux セッションへ適用."""
+        mock_is_tmux_running.return_value = True
+        mock_config_manager.get_project.return_value = ProjectConfig(
+            name="test-project",
+            environments={"MY_KEY": "my_value"},
+            tmux_windows=[WindowConfig(name="editor")],
+        )
+
+        orchestrator = ProjectOrchestrator(mock_config_manager, mock_iterm2_bridge)
+        await orchestrator.open("test-project")
+
+        mock_apply_env.assert_called_once_with(
+            "test-project", {"MY_KEY": "my_value"}
+        )
+
+    @pytest.mark.asyncio
+    @patch("itmux.orchestrator.apply_session_environments")
+    @patch('itmux.orchestrator.ProjectOrchestrator._is_tmux_running')
+    async def test_open_skips_env_when_all_windows_already_open(
+        self, mock_is_tmux_running, mock_apply_env,
+        mock_config_manager, mock_iterm2_bridge, mock_environ
+    ):
+        """全ウィンドウが既に開いていても environments は適用."""
+        mock_is_tmux_running.return_value = True
+        mock_window = AsyncMock()
+        mock_window.async_get_variable.return_value = "editor"
+        mock_iterm2_bridge.find_windows_by_project.return_value = [mock_window]
+        mock_config_manager.get_project.return_value = ProjectConfig(
+            name="test-project",
+            environments={"FOO": "bar"},
+            tmux_windows=[WindowConfig(name="editor")],
+        )
+
+        orchestrator = ProjectOrchestrator(mock_config_manager, mock_iterm2_bridge)
+        await orchestrator.open("test-project")
+
+        mock_iterm2_bridge.open_project_windows.assert_not_called()
+        mock_apply_env.assert_called_once_with("test-project", {"FOO": "bar"})


### PR DESCRIPTION
*🤖 by agents-ensemble (implementer)*

Closes #11

## Summary

- `ProjectConfig.environments: dict[str, str]` を追加（未指定時は空 dict、JSON 出力時も省略して後方互換）
- `src/itmux/tmux/environment.py` で `tmux set-environment -t <session>` による適用基盤を実装
- `itmux open` / `itmux add` 時に environments を適用
- ARCHITECTURE / USAGE を更新（tmux-resurrect 整合、`ITMUX_PROJECT` 記述の修正）

## 受け入れ条件対応

| 条件 | 対応 |
|------|------|
| `environments` 指定時、open 後のシェルで env が期待値 | `set-environment` でセッションスコープ適用。新規ペインで `echo $KEY` 可能 |
| 未指定時は現状維持 | 空 dict 時は no-op。既存 config そのまま読み込み可 |
| tmux-resurrect 復元との競合を文書化または解消 | ARCHITECTURE / USAGE に再適用タイミングと既存ペインの制限を記載。`open` で config 正本として上書き |
| テストで主要パスをカバー | models / environment / orchestrator の unit テスト追加 |

## Test plan

- [x] `uv run --extra dev pytest tests/itmux/ -q` — 87 passed
- [ ] 手動: config に `environments` を設定して `itmux open` → 新規ウィンドウで `echo $KEY`
- [ ] 手動: environments 未指定の既存 config で `itmux open` が従来どおり動作
- [ ] 手動: tmux-resurrect 復元後に `itmux open` で config 値が反映されること

## 設計メモ

- 適用ロジックは orchestrator から `tmux/environment.py` に分離（将来の cwd 適用拡張を見据え）
- 既存ペインのシェルは tmux 仕様上 `set-environment` だけでは更新されない → 文書で案内


Made with [Cursor](https://cursor.com)