### PR TITLE
feat: itmux config サブコマンドと cwd データモデルを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ iTmux/
 itmux open <project>     # プロジェクトを開く/復元
 itmux close <project>    # プロジェクトをデタッチ
 itmux list              # プロジェクト一覧
+itmux config show <project>              # プロジェクト設定を表示
+itmux config set cwd <project> <path>    # 作業ディレクトリを設定
+itmux config unset cwd <project>         # 作業ディレクトリを削除
 ```
 
 ## 開発環境

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ iTmuxは、iTerm2のPython APIとtmuxのControl Modeを組み合わせて、プ�
 - `itmux open <project>`: プロジェクトのウィンドウセットを開く/復元
 - `itmux close <project>`: プロジェクトの状態を保存してデタッチ
 - `itmux list`: 管理中のプロジェクト一覧
+- `itmux config show <project>`: プロジェクト設定を表示
+- `itmux config set cwd <project> <path>`: 作業ディレクトリ（cwd）を設定
+- `itmux config unset cwd <project>`: 作業ディレクトリ（cwd）を削除
 
 ## 技術スタック
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -280,8 +280,8 @@ src/itmux/
 
 #### `cli.py`
 - Clickベースのコマンドラインインターフェース
-- `open`, `close`, `list` コマンドの定義
-- orchestratorへの処理委譲
+- `open`, `close`, `list`, `config` コマンドの定義
+- orchestratorへの処理委譲（`config` 系は `ConfigManager` のみで完結）
 
 #### `config.py`
 - `~/.itmux/config.json` の読み込み/保存
@@ -369,6 +369,22 @@ $ itmux add           # webappに追加
 $ itmux close         # webappを閉じる
 ```
 
+### プロジェクト設定（config）
+
+iTerm2 接続不要。`ConfigManager` のみで完結する。
+
+```bash
+# プロジェクト設定を表示
+itmux config show <project>
+
+# 作業ディレクトリ（cwd）を設定
+itmux config set cwd <project> <path>
+# → 存在しないパス・ファイルは ConfigError
+
+# 作業ディレクトリを削除
+itmux config unset cwd <project>
+```
+
 ## データ構造
 
 ### 設定ファイル（`~/.itmux/config.json`）
@@ -377,6 +393,9 @@ $ itmux close         # webappを閉じる
 {
   "projects": {
     "my-project": {
+      "name": "my-project",
+      "description": "optional description",
+      "cwd": "/Users/me/Develop/my-project",
       "tmux_windows": [
         {
           "name": "my_editor",
@@ -418,7 +437,9 @@ class SessionConfig:
 @dataclass
 class ProjectConfig:
     name: str
-    sessions: list[SessionConfig]
+    description: Optional[str] = None
+    cwd: Optional[Path] = None  # ~ 展開・絶対パス正規化。省略時は None
+    tmux_windows: list[WindowConfig]
     environments: dict[str, str]  # 省略時は {}
 ```
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -9,6 +9,7 @@ iTmuxは、iTerm2とtmuxを組み合わせて、プロジェクト単位でタ�
   - [tmux-resurrect統合](#tmux-resurrect統合)
 - [基本概念](#基本概念)
 - [基本的な使い方](#基本的な使い方)
+- [プロジェクト設定の変更（config）](#プロジェクト設定の変更config)
 - [プロジェクト定義](#プロジェクト定義)
 - [実践例](#実践例)
 - [トラブルシューティング](#トラブルシューティング)
@@ -365,6 +366,55 @@ itmux current
 - 現在のプロジェクトが明確（`itmux current` で確認）
 - 複数プロジェクトを開いていても、各session内で正しく動作
 
+## プロジェクト設定の変更（config）
+
+`config.json` を手編集せず、CLI からプロジェクト設定を閲覧・変更できます。**設定の変更は CLI を第一選択肢**としてください（iTerm2 接続は不要です）。
+
+### 設定の表示
+
+```bash
+itmux config show my-project
+```
+
+**出力例**:
+```
+Project: my-project
+Name: my-project
+Description: 開発用のメインプロジェクト
+Cwd: /Users/me/Develop/my-project
+Windows:
+  - editor
+  - server
+```
+
+### 作業ディレクトリ（cwd）の設定
+
+プロジェクトごとのデフォルト作業ディレクトリを設定します（`~` 展開・絶対パスへの正規化あり）。
+
+```bash
+# cwd を設定
+itmux config set cwd my-project ~/Develop/my-project
+
+# cwd を削除
+itmux config unset cwd my-project
+```
+
+**エラー時の挙動**:
+- 存在しないパス: `✗ Config Error: Directory does not exist: ...`
+- ファイルを指定した場合: `✗ Config Error: Not a directory: ...`
+- プロジェクトが存在しない: `✗ Error: Project '...' not found`
+
+存在しないディレクトリを先に config に書きたい場合は、手編集（下記）も利用できます。CLI 経由では、ディレクトリを作成してから `config set cwd` を実行してください。
+
+### 手編集（上級者向け）
+
+CLI で対応していない項目や、一括編集が必要な場合のみ `config.json` を直接編集します。
+
+```bash
+mkdir -p ~/.itmux
+nvim ~/.itmux/config.json
+```
+
 ## プロジェクト定義
 
 ### 命名規則
@@ -411,6 +461,13 @@ karte/systems-track     # /で階層を表現
 
 プロジェクトには説明文を追加できます（オプション）：
 
+```bash
+# 説明は itmux config show で確認可能（設定は現状 JSON 手編集）
+itmux config show my-project
+```
+
+JSON で直接編集する場合：
+
 ```json
 {
   "projects": {
@@ -451,6 +508,34 @@ Projects:
 - `lines`: 行数（縦幅）
 
 省略した場合、デフォルトサイズで開きます。
+
+### 作業ディレクトリ（cwd）
+
+プロジェクトごとにデフォルトの作業ディレクトリを設定できます。
+
+```bash
+itmux config set cwd my-project ~/Develop/my-project
+itmux config show my-project   # Cwd: /Users/me/Develop/my-project
+itmux config unset cwd my-project
+```
+
+JSON で直接編集する場合（`~` は読み込み時に展開されます）：
+
+```json
+{
+  "projects": {
+    "my-project": {
+      "name": "my-project",
+      "cwd": "/Users/me/Develop/my-project",
+      "tmux_windows": [
+        {"name": "editor"}
+      ]
+    }
+  }
+}
+```
+
+**注意**: 起動時の cwd 適用は将来のバージョンで対応予定です。現時点では設定の永続化のみです。
 
 ### プロジェクト環境変数（environments）
 
@@ -697,6 +782,8 @@ itmux close
 ### 設定ファイルの場所
 
 デフォルト: `~/.itmux/config.json`
+
+設定の変更は **`itmux config`** コマンドを優先してください（[プロジェクト設定の変更](#プロジェクト設定の変更config) を参照）。手編集が必要な場合：
 
 ```bash
 # ディレクトリ作成

--- a/src/itmux/cli.py
+++ b/src/itmux/cli.py
@@ -28,6 +28,56 @@ async def get_orchestrator() -> ProjectOrchestrator:
     return ProjectOrchestrator(config_manager, bridge)
 
 
+def get_config_manager() -> ConfigManager:
+    """ConfigManager インスタンスを作成（ITMUX_CONFIG_PATH 対応）."""
+    config_path_str = os.environ.get("ITMUX_CONFIG_PATH")
+    config_path = Path(config_path_str) if config_path_str else DEFAULT_CONFIG_PATH
+    return ConfigManager(config_path)
+
+
+def handle_config_errors(func):
+    """Config 系コマンドの共通エラーハンドリング."""
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ProjectNotFoundError as e:
+            click.echo(f"✗ Error: {e}", err=True)
+            sys.exit(1)
+        except ConfigError as e:
+            click.echo(f"✗ Config Error: {e}", err=True)
+            sys.exit(1)
+        except ValueError as e:
+            click.echo(f"✗ Error: {e}", err=True)
+            sys.exit(1)
+
+    wrapper.__name__ = func.__name__
+    wrapper.__doc__ = func.__doc__
+    return wrapper
+
+
+def format_project_config(project_name: str, project) -> str:
+    """プロジェクト設定を人間可読形式に整形."""
+    lines = [f"Project: {project_name}"]
+    lines.append(f"Name: {project.name}")
+
+    if project.description:
+        lines.append(f"Description: {project.description}")
+
+    if project.cwd:
+        lines.append(f"Cwd: {project.cwd}")
+    else:
+        lines.append("Cwd: (not set)")
+
+    if project.tmux_windows:
+        lines.append("Windows:")
+        for window in project.tmux_windows:
+            lines.append(f"  - {window.name}")
+    else:
+        lines.append("Windows: (none)")
+
+    return "\n".join(lines)
+
+
 def run_async_command(coro, success_message: str, handle_value_error: bool = False):
     """非同期コマンドを実行し、共通のエラーハンドリングを適用.
 
@@ -128,6 +178,56 @@ def add(project: str | None, window: str | None):
         await orchestrator.add(project, window)
 
     run_async_command(_add(), f"✓ Added window to project: {project or 'current'}", handle_value_error=True)
+
+
+@main.group()
+def config():
+    """Manage project configuration."""
+    pass
+
+
+@config.command("show")
+@click.argument("project")
+@handle_config_errors
+def config_show(project: str):
+    """Show project configuration."""
+    manager = get_config_manager()
+    project_config = manager.get_project(project)
+    click.echo(format_project_config(project, project_config))
+
+
+@config.group("set")
+def config_set():
+    """Set project configuration values."""
+    pass
+
+
+@config_set.command("cwd")
+@click.argument("project")
+@click.argument("path")
+@handle_config_errors
+def config_set_cwd(project: str, path: str):
+    """Set the working directory for a project."""
+    manager = get_config_manager()
+    manager.set_project_cwd(project, path)
+    project_config = manager.get_project(project)
+    click.echo(f"✓ Set cwd for project '{project}': {project_config.cwd}")
+
+
+@config.group("unset")
+def config_unset():
+    """Unset project configuration values."""
+    pass
+
+
+@config_unset.command("cwd")
+@click.argument("project")
+@handle_config_errors
+def config_unset_cwd(project: str):
+    """Remove the working directory setting for a project."""
+    manager = get_config_manager()
+    manager.unset_project_cwd(project)
+    click.echo(f"✓ Unset cwd for project '{project}'")
 
 
 @main.command()

--- a/src/itmux/config.py
+++ b/src/itmux/config.py
@@ -74,7 +74,7 @@ class ConfigManager:
         with FileLock(self.lock_path, timeout=10):
             try:
                 with open(self.config_path, "w", encoding="utf-8") as f:
-                    data = config.model_dump(exclude_none=True)
+                    data = config.model_dump(mode="json", exclude_none=True)
                     json.dump(data, f, indent=2, ensure_ascii=False)
                     f.write("\n")  # 末尾改行
             except Exception as e:
@@ -166,6 +166,50 @@ class ConfigManager:
         project.tmux_windows.append(window)
 
         # 自動保存
+        self.save()
+
+    def set_project_cwd(self, project_name: str, cwd: str | Path) -> None:
+        """プロジェクトの作業ディレクトリを設定.
+
+        Args:
+            project_name: プロジェクト名
+            cwd: 作業ディレクトリパス
+
+        Raises:
+            ProjectNotFoundError: プロジェクトが存在しない
+            ConfigError: パスが存在しない、またはディレクトリでない
+        """
+        if self._config is None:
+            self.load()
+
+        if project_name not in self._config.projects:
+            raise ProjectNotFoundError(f"Project '{project_name}' not found")
+
+        path = Path(cwd).expanduser().resolve(strict=False)
+        if not path.exists():
+            raise ConfigError(f"Directory does not exist: {path}")
+        if not path.is_dir():
+            raise ConfigError(f"Not a directory: {path}")
+
+        self._config.projects[project_name].cwd = path
+        self.save()
+
+    def unset_project_cwd(self, project_name: str) -> None:
+        """プロジェクトの作業ディレクトリを削除.
+
+        Args:
+            project_name: プロジェクト名
+
+        Raises:
+            ProjectNotFoundError: プロジェクトが存在しない
+        """
+        if self._config is None:
+            self.load()
+
+        if project_name not in self._config.projects:
+            raise ProjectNotFoundError(f"Project '{project_name}' not found")
+
+        self._config.projects[project_name].cwd = None
         self.save()
 
     def create_project(

--- a/src/itmux/models.py
+++ b/src/itmux/models.py
@@ -1,5 +1,6 @@
 """iTmux data models using Pydantic."""
 
+from pathlib import Path
 from typing import Optional, Any
 from pydantic import BaseModel, Field, field_validator, model_serializer
 
@@ -44,6 +45,7 @@ class ProjectConfig(BaseModel):
 
     name: str = Field(min_length=1, description="プロジェクト名")
     description: Optional[str] = Field(default=None, description="プロジェクトの説明")
+    cwd: Optional[Path] = Field(default=None, description="作業ディレクトリ")
     environments: dict[str, str] = Field(
         default_factory=dict, description="セッションスコープの環境変数"
     )
@@ -61,6 +63,15 @@ class ProjectConfig(BaseModel):
             if char in v:
                 raise ValueError(f'project name cannot contain "{char}"')
         return v
+
+    @field_validator("cwd", mode="before")
+    @classmethod
+    def normalize_cwd(cls, v: str | Path | None) -> Path | None:
+        """cwd を絶対パスに正規化（~ 展開、resolve）."""
+        if v is None:
+            return None
+        path = Path(v).expanduser()
+        return path.resolve(strict=False)
 
     @field_validator("environments")
     @classmethod

--- a/tests/itmux/test_cli.py
+++ b/tests/itmux/test_cli.py
@@ -1,5 +1,6 @@
 """tests/itmux/test_cli.py - CLIコマンドのテスト."""
 
+import json
 import pytest
 from click.testing import CliRunner
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -273,3 +274,131 @@ class TestCurrent:
 
         assert result.exit_code == 1
         assert result.output == ""  # 何も出力しない
+
+
+class TestConfig:
+    """config サブコマンドのテスト."""
+
+    @pytest.fixture
+    def config_file(self, tmp_path):
+        """テスト用設定ファイル."""
+        config_path = tmp_path / "config.json"
+        data = {
+            "projects": {
+                "test-project": {
+                    "name": "test-project",
+                    "description": "Test project",
+                    "tmux_windows": [
+                        {"name": "editor"},
+                        {"name": "server"},
+                    ],
+                }
+            }
+        }
+        with open(config_path, "w") as f:
+            json.dump(data, f)
+        return config_path
+
+    def test_config_show(self, config_file):
+        """プロジェクト設定表示."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["config", "show", "test-project"],
+            env={"ITMUX_CONFIG_PATH": str(config_file)},
+        )
+
+        assert result.exit_code == 0
+        assert "Project: test-project" in result.output
+        assert "Name: test-project" in result.output
+        assert "Description: Test project" in result.output
+        assert "Cwd: (not set)" in result.output
+        assert "Windows:" in result.output
+        assert "editor" in result.output
+        assert "server" in result.output
+
+    def test_config_show_project_not_found(self, config_file):
+        """存在しないプロジェクト."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["config", "show", "nonexistent"],
+            env={"ITMUX_CONFIG_PATH": str(config_file)},
+        )
+
+        assert result.exit_code == 1
+        assert "✗ Error: Project 'nonexistent' not found" in result.output
+
+    def test_config_set_cwd(self, config_file, tmp_path):
+        """cwd 設定."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["config", "set", "cwd", "test-project", str(tmp_path)],
+            env={"ITMUX_CONFIG_PATH": str(config_file)},
+        )
+
+        assert result.exit_code == 0
+        assert f"✓ Set cwd for project 'test-project': {tmp_path.resolve()}" in result.output
+
+        with open(config_file) as f:
+            data = json.load(f)
+        assert data["projects"]["test-project"]["cwd"] == str(tmp_path.resolve())
+
+    def test_config_set_cwd_nonexistent_path(self, config_file):
+        """存在しないパスはエラー."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["config", "set", "cwd", "test-project", "/nonexistent/path"],
+            env={"ITMUX_CONFIG_PATH": str(config_file)},
+        )
+
+        assert result.exit_code == 1
+        assert "✗ Config Error: Directory does not exist" in result.output
+
+    def test_config_set_cwd_project_not_found(self, config_file, tmp_path):
+        """存在しないプロジェクト."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["config", "set", "cwd", "nonexistent", str(tmp_path)],
+            env={"ITMUX_CONFIG_PATH": str(config_file)},
+        )
+
+        assert result.exit_code == 1
+        assert "✗ Error: Project 'nonexistent' not found" in result.output
+
+    def test_config_unset_cwd(self, config_file, tmp_path):
+        """cwd 削除."""
+        with open(config_file) as f:
+            data = json.load(f)
+        data["projects"]["test-project"]["cwd"] = str(tmp_path)
+        with open(config_file, "w") as f:
+            json.dump(data, f)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["config", "unset", "cwd", "test-project"],
+            env={"ITMUX_CONFIG_PATH": str(config_file)},
+        )
+
+        assert result.exit_code == 0
+        assert "✓ Unset cwd for project 'test-project'" in result.output
+
+        with open(config_file) as f:
+            data = json.load(f)
+        assert "cwd" not in data["projects"]["test-project"]
+
+    def test_config_unset_cwd_project_not_found(self, config_file):
+        """存在しないプロジェクトの cwd 削除."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["config", "unset", "cwd", "nonexistent"],
+            env={"ITMUX_CONFIG_PATH": str(config_file)},
+        )
+
+        assert result.exit_code == 1
+        assert "✗ Error: Project 'nonexistent' not found" in result.output

--- a/tests/itmux/test_config.py
+++ b/tests/itmux/test_config.py
@@ -232,6 +232,84 @@ class TestConfigManager:
         assert "my-project" in data["projects"]
         assert "tmux_windows" in data["projects"]["my-project"]
 
+    def test_set_project_cwd(self, temp_config_file, sample_config_data, tmp_path):
+        """cwd 設定."""
+        with open(temp_config_file, "w") as f:
+            json.dump(sample_config_data, f)
+
+        manager = ConfigManager(temp_config_file)
+        manager.load()
+        manager.set_project_cwd("test-project", tmp_path)
+
+        project = manager.get_project("test-project")
+        assert project.cwd == tmp_path.resolve()
+
+        with open(temp_config_file) as f:
+            data = json.load(f)
+        assert data["projects"]["test-project"]["cwd"] == str(tmp_path.resolve())
+
+    def test_set_project_cwd_nonexistent_raises_error(
+        self, temp_config_file, sample_config_data
+    ):
+        """存在しないディレクトリはエラー."""
+        with open(temp_config_file, "w") as f:
+            json.dump(sample_config_data, f)
+
+        manager = ConfigManager(temp_config_file)
+        manager.load()
+
+        with pytest.raises(ConfigError, match="Directory does not exist"):
+            manager.set_project_cwd("test-project", "/nonexistent/path")
+
+    def test_set_project_cwd_file_raises_error(
+        self, temp_config_file, sample_config_data, tmp_path
+    ):
+        """ファイルパスはエラー."""
+        file_path = tmp_path / "file.txt"
+        file_path.write_text("test")
+
+        with open(temp_config_file, "w") as f:
+            json.dump(sample_config_data, f)
+
+        manager = ConfigManager(temp_config_file)
+        manager.load()
+
+        with pytest.raises(ConfigError, match="Not a directory"):
+            manager.set_project_cwd("test-project", file_path)
+
+    def test_set_project_cwd_nonexistent_project_raises_error(self, temp_config_file):
+        """存在しないプロジェクトはエラー."""
+        manager = ConfigManager(temp_config_file)
+        manager.load()
+
+        with pytest.raises(ProjectNotFoundError):
+            manager.set_project_cwd("nonexistent", "/tmp")
+
+    def test_unset_project_cwd(self, temp_config_file, sample_config_data, tmp_path):
+        """cwd 削除."""
+        sample_config_data["projects"]["test-project"]["cwd"] = str(tmp_path)
+        with open(temp_config_file, "w") as f:
+            json.dump(sample_config_data, f)
+
+        manager = ConfigManager(temp_config_file)
+        manager.load()
+        manager.unset_project_cwd("test-project")
+
+        project = manager.get_project("test-project")
+        assert project.cwd is None
+
+        with open(temp_config_file) as f:
+            data = json.load(f)
+        assert "cwd" not in data["projects"]["test-project"]
+
+    def test_unset_project_cwd_nonexistent_raises_error(self, temp_config_file):
+        """存在しないプロジェクトの cwd 削除はエラー."""
+        manager = ConfigManager(temp_config_file)
+        manager.load()
+
+        with pytest.raises(ProjectNotFoundError):
+            manager.unset_project_cwd("nonexistent")
+
 
 class TestFunctionAPI:
     """関数APIのテスト."""

--- a/tests/itmux/test_models.py
+++ b/tests/itmux/test_models.py
@@ -148,6 +148,31 @@ class TestProjectConfig:
         project = ProjectConfig(name="my-project")
         assert project.description is None
 
+    def test_project_with_cwd(self, tmp_path):
+        """cwd 付きプロジェクト."""
+        project = ProjectConfig(name="my-project", cwd=tmp_path)
+        assert project.cwd == tmp_path.resolve()
+
+    def test_project_cwd_expands_tilde(self, monkeypatch, tmp_path):
+        """cwd の ~ 展開."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        project = ProjectConfig(name="my-project", cwd="~/work")
+        assert project.cwd == (tmp_path / "work").resolve()
+
+    def test_project_without_cwd_defaults_none(self):
+        """cwd 未指定は None."""
+        project = ProjectConfig(name="my-project")
+        assert project.cwd is None
+
+    def test_backward_compatible_json_without_cwd(self):
+        """cwd なしの既存 config が読み込める."""
+        data = {
+            "name": "legacy-project",
+            "tmux_windows": [{"name": "main"}],
+        }
+        project = ProjectConfig.model_validate(data)
+        assert project.cwd is None
+
     def test_project_with_environments(self):
         """環境変数付きプロジェクト."""
         project = ProjectConfig(


### PR DESCRIPTION
## Summary

- `itmux config` サブコマンドグループを追加（`show` / `set cwd` / `unset cwd`）
- #7 未マージのため、`ProjectConfig.cwd` と `ConfigManager.set_project_cwd` / `unset_project_cwd` を同梱
- iTerm2 接続不要。`ITMUX_CONFIG_PATH` 環境変数でテスト用 config パスを指定可能

## 受け入れ条件との対応

| 受け入れ条件 | 対応 |
|-------------|------|
| `config` サブコマンドグループ登録 | `cli.py` に `@main.group() config` を追加 |
| `show` と cwd の `set` / `unset` 動作 | 実装済み。`config` 系は `ConfigManager` のみで完結 |
| エラーメッセージ（プロジェクト未存在等） | `✗ Error:` / `✗ Config Error:` 形式で既存 CLI と統一 |
| テストあり | `test_cli.py` / `test_config.py` / `test_models.py` に追加 |

## #7 同梱内容

- `ProjectConfig.cwd: Path | None`（`~` 展開・絶対パス正規化）
- `ConfigManager.set_project_cwd` / `unset_project_cwd`
- バリデーション方針: モデルは正規化のみ、CLI 経由の set は存在しないパスをエラー（詳細は Issue #8 コメント参照）
- 後方互換: cwd 未指定の既存 config はそのまま読み込み可能

## Test plan

- [x] `uv run pytest`（unit 108 件 pass、e2e は未実施）
- [x] `itmux config show <project>` — 人間可読出力（name, description, cwd, windows）
- [x] `itmux config set cwd <project> <path>` — 永続化・正規化
- [x] `itmux config unset cwd <project>` — cwd キー削除
- [x] 存在しないプロジェクト / 存在しないパスでエラー出力
- [ ] 実機 iTerm2 上での手動確認（config 系は iTerm2 不要のため省略）

Closes #8

*🤖 by agents-ensemble (implementer)*

Made with [Cursor](https://cursor.com)