### PR TITLE
fix: cwd 指定時もネイティブウィンドウで追加する (#15)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,13 +198,18 @@ set-environment -g PATH "/opt/homebrew/bin:$PATH"
 3. TmuxConnection取得
    tmux_conn = get_tmux_connection(project)
 
-4. 新しいtmuxウィンドウを作成
+4. 新しいtmuxウィンドウを作成（常に iTerm2 ネイティブウィンドウ）
    iterm_window = await tmux_conn.async_create_window()
-   await tmux_conn.async_send_command(f"rename-window {window-name}")
+   # cwd 指定時: respawn-pane -c で pane を再起動し作業ディレクトリを適用
+   # （new-window -c は同一 iTerm ウィンドウ内タブになるため使用しない）
+   if project.cwd:
+     await tmux_conn.async_send_command(
+       f"respawn-pane -t @{tmux_window_id} -c {project.cwd} -k"
+     )
+   await iterm_window.async_activate()  # view-mode 遷移防止
 
 5. iTerm2ウィンドウにタグ付け
-   await iterm_window.async_set_variable("user.projectID", project)
-   await iterm_window.async_set_variable("user.window_name", window-name)
+   await window_manager.tag_window(iterm_window, project, window-name)
 
 6. 完了（自動同期）
    → 新しいiTerm2ウィンドウが開く
@@ -513,10 +518,18 @@ fi
 
 ### 適用方式
 
-- **新規ウィンドウ**（`open` の差分オープン、`add`）: `tmux new-session` / `new-window` の `-c` でシェル起動時に cwd を設定
+cwd の適用経路は **初回セッション接続** と **追加ウィンドウ作成** で異なります。
+
+| 場面 | ウィンドウ作成 | cwd 適用 |
+|------|----------------|----------|
+| **初回セッション接続**（`open` でセッション新規作成） | `tmux new-session`（Control Mode attach 前） | `new-session -c` / `new-window -c` でシェル起動時に設定 |
+| **追加ウィンドウ**（`open` の差分オープン、`add`） | `async_create_window()`（iTerm2 ネイティブウィンドウ） | 作成後 `respawn-pane -t @<id> -c <path> -k` で pane を再起動 |
+
 - **全ウィンドウ既存の `open`**: cwd は再適用しない（既存ペインは起動時 cwd のまま。environments と同様）
 - **未指定時**: `cwd` 省略または未設定 → 何も変更しない（後方互換）
 - **runtime 検証**: `open` / `add` 実行時にパスが存在しない場合はエラー（`config set cwd` 時の検証とは別レイヤ）
+
+追加ウィンドウで `new-window -c` を使わない理由: Control Mode 下では同一 iTerm2 ウィンドウ内のタブとして開かれ、ネイティブウィンドウにならない（#15）。
 
 ### tmux-resurrect との整合
 
@@ -525,9 +538,10 @@ tmux-resurrect はペインの作業ディレクトリも保存・復元しま�
 | タイミング | 動作 |
 |-----------|------|
 | resurrect 復元直後 | 保存時点のディレクトリが復元される |
-| `itmux open`（新規ウィンドウあり） | config の `cwd` で `-c` 起動 |
+| `itmux open`（セッション新規作成） | `new-session -c` で初回ウィンドウの cwd を設定 |
+| `itmux open`（差分で新規ウィンドウあり） | `async_create_window()` + `respawn-pane -c` で cwd を適用 |
 | `itmux open`（全ウィンドウ既存） | cwd は変更しない |
-| `itmux add` | 新規ウィンドウのみ config の `cwd` で起動 |
+| `itmux add` | `async_create_window()` + `respawn-pane -c` で cwd を適用 |
 
 **既存ペインのシェル**は、environments と同様、起動時の cwd を維持します。`itmux open` で既存ペインの cwd を変更する機能はありません。
 

--- a/src/itmux/iterm2/bridge.py
+++ b/src/itmux/iterm2/bridge.py
@@ -1,7 +1,6 @@
 """iTerm2 Python API integration layer."""
 
 import asyncio
-import shlex
 from pathlib import Path
 from typing import Optional
 
@@ -9,6 +8,7 @@ import iterm2
 
 from ..models import WindowSize, WindowConfig
 from ..exceptions import ITerm2Error
+from ..tmux.cwd import cwd_respawn_pane_command
 from ..tmux.session_manager import SessionManager
 from ..tmux.hook_manager import HookManager
 from .window_manager import WindowManager
@@ -165,28 +165,34 @@ class ITerm2Bridge:
         except Exception:
             pass
 
+    async def _apply_window_cwd(
+        self,
+        tmux_conn: iterm2.TmuxConnection,
+        iterm_window: iterm2.Window,
+        cwd: Path,
+    ) -> None:
+        """ネイティブウィンドウ作成後に pane の作業ディレクトリを適用."""
+        tab = iterm_window.current_tab
+        tmux_window_id = tab.tmux_window_id
+        if not tmux_window_id:
+            raise ITerm2Error(
+                "Failed to apply cwd: tmux window id not available on new window"
+            )
+        await tmux_conn.async_send_command(
+            cwd_respawn_pane_command(str(tmux_window_id), cwd)
+        )
+
     async def _create_tmux_window(
         self,
         tmux_conn: iterm2.TmuxConnection,
         project_name: str,
         cwd: Optional[Path] = None,
     ) -> iterm2.Window:
-        """tmux ウィンドウを作成し、対応する iTerm2 ウィンドウを返す."""
+        """tmux ウィンドウを作成し、対応する iTerm2 ネイティブウィンドウを返す."""
+        iterm_window = await tmux_conn.async_create_window()
         if cwd is not None:
-            path = shlex.quote(str(cwd))
-            await tmux_conn.async_send_command(
-                f"new-window -t {project_name} -c {path}"
-            )
-            await asyncio.sleep(0.05)
-            matched_windows = await self.find_windows_by_tmux_session(tmux_conn)
-            if not matched_windows:
-                raise ITerm2Error(
-                    f"Failed to find iTerm2 window after tmux new-window for: {project_name}"
-                )
-            matched_windows.sort(key=lambda x: int(x[2]))
-            return matched_windows[-1][0]
-
-        return await tmux_conn.async_create_window()
+            await self._apply_window_cwd(tmux_conn, iterm_window, cwd)
+        return iterm_window
 
     async def add_window(
         self,

--- a/src/itmux/tmux/cwd.py
+++ b/src/itmux/tmux/cwd.py
@@ -1,5 +1,6 @@
 """tmuxセッションへの作業ディレクトリ（cwd）適用."""
 
+import shlex
 from pathlib import Path
 from typing import Optional
 
@@ -26,3 +27,14 @@ def cwd_creation_args(cwd: Optional[Path]) -> list[str]:
     if cwd is None:
         return []
     return ["-c", str(cwd)]
+
+
+def cwd_respawn_pane_command(tmux_window_id: str, cwd: Path) -> str:
+    """iTerm2 ネイティブウィンドウ作成後に pane の cwd を適用する tmux コマンド.
+
+    async_create_window() では起動時 cwd を指定できないため、
+    new-window -c と同等の開始ディレクトリを respawn-pane で設定する。
+    """
+    path = shlex.quote(str(cwd))
+    wid = tmux_window_id.lstrip("@")
+    return f"respawn-pane -t @{wid} -c {path} -k"

--- a/tests/itmux/test_cwd.py
+++ b/tests/itmux/test_cwd.py
@@ -4,7 +4,7 @@ import pytest
 from pathlib import Path
 
 from itmux.exceptions import CwdError
-from itmux.tmux.cwd import cwd_creation_args, validate_cwd_path
+from itmux.tmux.cwd import cwd_creation_args, cwd_respawn_pane_command, validate_cwd_path
 
 
 class TestValidateCwdPath:
@@ -36,3 +36,18 @@ class TestCwdCreationArgs:
     def test_path_returns_c_flag(self, tmp_path):
         path = tmp_path.resolve()
         assert cwd_creation_args(path) == ["-c", str(path)]
+
+
+class TestCwdRespawnPaneCommand:
+    """cwd_respawn_pane_command() のテスト."""
+
+    def test_builds_respawn_pane_with_cwd(self, tmp_path):
+        path = tmp_path.resolve()
+        cmd = cwd_respawn_pane_command("42", path)
+        assert cmd == f"respawn-pane -t @42 -c {path} -k"
+
+    def test_strips_at_prefix_from_window_id(self, tmp_path):
+        path = tmp_path.resolve()
+        cmd = cwd_respawn_pane_command("@99", path)
+        assert "@99" in cmd
+        assert "@@99" not in cmd

--- a/tests/itmux/test_iterm2_bridge.py
+++ b/tests/itmux/test_iterm2_bridge.py
@@ -137,25 +137,28 @@ class TestCreateTmuxWindow:
         tmux_conn.async_create_window.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_create_with_cwd_uses_new_window_command(
+    async def test_create_with_cwd_uses_api_and_applies_cwd(
         self, mock_iterm2_connection, mock_iterm2_app, tmp_path
     ):
-        """cwd 指定時は tmux new-window -c を使う."""
+        """cwd 指定時も async_create_window を使い、respawn-pane で cwd を適用する."""
         cwd = tmp_path.resolve()
         tmux_conn = AsyncMock()
+        expected_window = AsyncMock()
+        tab = MagicMock()
+        tab.tmux_window_id = "42"
+        expected_window.current_tab = tab
+        tmux_conn.async_create_window = AsyncMock(return_value=expected_window)
         tmux_conn.async_send_command = AsyncMock()
 
-        expected_window = AsyncMock()
         bridge = ITerm2Bridge(mock_iterm2_connection, mock_iterm2_app)
-        bridge.find_windows_by_tmux_session = AsyncMock(
-            return_value=[(expected_window, "1", "0")]
-        )
-
         result = await bridge._create_tmux_window(tmux_conn, "my-project", cwd=cwd)
 
         assert result is expected_window
+        tmux_conn.async_create_window.assert_awaited_once()
         tmux_conn.async_send_command.assert_awaited_once()
         cmd = tmux_conn.async_send_command.await_args.args[0]
-        assert "new-window" in cmd
+        assert "respawn-pane" in cmd
         assert "-c" in cmd
         assert str(cwd) in cmd
+        assert "-k" in cmd
+        assert "@42" in cmd


### PR DESCRIPTION
## Summary

- `_create_tmux_window()` が cwd 有無で `async_create_window()` と `new-window -c` に分岐していたため、cwd 設定済みプロジェクトで `itmux add` / `open` の差分ウィンドウが iTerm2 タブとして開いていた（#9 によるデグレ）
- 常に `async_create_window()` でネイティブウィンドウを作成し、cwd は `respawn-pane -c -k` で適用する（`cwd_respawn_pane_command()` を `tmux/cwd.py` に追加）
- `add_window` / `tag_session_windows` は同一経路のため同時に修正

## 受け入れ条件との対応

| 条件 | 対応 |
|------|------|
| cwd あり/なしで `itmux add` がネイティブウィンドウ | `_create_tmux_window()` を常に `async_create_window()` に統一 |
| cwd 指定時のシェル cwd が config と一致 | 作成後 `respawn-pane -t @<id> -c <path> -k` で適用 |
| `open` 時の追加ウィンドウもネイティブ | `tag_session_windows()` も `_create_tmux_window()` 経由で同一修正 |
| 回帰テスト更新 | `test_iterm2_bridge.py`, `test_cwd.py` を更新 |

## Test plan

- [x] `pytest tests/itmux/test_iterm2_bridge.py tests/itmux/test_cwd.py`
- [x] `pytest`（全テスト 627 件）
- [ ] 手動: cwd 設定あり/なしで `itmux add` がネイティブウィンドウとして開く
- [ ] 手動: cwd 設定ありで追加ウィンドウのシェル cwd が config と一致
- [ ] 手動: `open` 時の差分ウィンドウ作成がネイティブウィンドウになる

Closes #15

Made with [Cursor](https://cursor.com)