### PR TITLE
docs: attach 後 cwd + ネイティブウィンドウ探索レポート (#17)

### DIFF
--- a/docs/reports/research-report.attach-window-cwd.v1.md
+++ b/docs/reports/research-report.attach-window-cwd.v1.md
@@ -1,0 +1,177 @@
+# attach 後追加ウィンドウの cwd + ネイティブウィンドウ調査レポート v1
+
+調査日: 2026-08-18  
+Issue: [#17](https://github.com/otolab/iTmux/issues/17)  
+比較ベースライン: PR #16（`async_create_window()` + `respawn-pane -c -k`）
+
+## 概要
+
+attach 済み Control Mode 下で、**iTerm2 ネイティブウィンドウ**かつ**起動時 cwd**（`new-window -c` 相当）を同時に満たす経路を候補 A〜D で調査した。
+
+**結論**: 現行 iTerm2 Python API / tmux 3.6a の組み合わせでは、**PR #16 の `async_create_window()` + `respawn-pane -c -k` が唯一の実用解**。より素直な代替案は見つからなかった。
+
+## 調査環境
+
+| 項目 | 値 |
+|------|-----|
+| macOS | darwin 24.6.0 |
+| iTerm2 | 3.6.11（`iTermServer-3.6.11`） |
+| tmux | 3.6a |
+| iterm2 (PyPI) | **2.20**（プロジェクト制約 `>=2.7`、調査時点の最新） |
+| 検証セッション | `issue17-test`（`tmux -CC attach` 済み） |
+| 再現スクリプト | `scripts/research/issue17_*.py`, `issue17_cwd_shell_test.sh` |
+
+## 制約（再確認）
+
+| 項目 | 内容 | 確度 |
+|------|------|------|
+| `TmuxConnection.async_create_window()` | 引数なし。内部 RPC は `create_window { connection_id, affinity? }` のみ | **高**（iterm2 2.20 ソース + upstream `api.proto`） |
+| `new-window -c`（CC 経路） | 起動 cwd は満たすが **同一 iTerm ウィンドウ内タブ**になる | **高**（実機 + #15） |
+| `default-path` | **tmux 1.9 で削除**。tmux 3.6a では `invalid option` | **高**（実機） |
+| attach 前 `new-session -c` | ネイティブ + 起動 cwd を満たす | **高**（`environment.py`） |
+
+## iterm2 ライブラリ版調査（オペレータ要望）
+
+| バージョン | `async_create_window` cwd | `async_rpc_create_tmux_window` | 備考 |
+|-----------|---------------------------|-------------------------------|------|
+| 制約下限 2.7 | なし | 調査対象外（古い） | pyproject.toml |
+| 最新 2.20（実機） | なし | `affinity` のみ追加、**cwd なし** | `.venv` インストール版 |
+| upstream master | なし | proto `CreateWindow` に `connection_id`, `affinity` のみ | GitHub `api.proto` |
+
+**判断**: より新しい iterm2 ライブラリ（2.20）でも cwd / create_window 対応は**入っていない**。iTerm2 アプリ本体の RPC スキーマに cwd フィールドが無いため、Python 側だけの更新では解決しない。
+
+## 候補評価結果表
+
+評価軸: ○=満たす / △=部分的 / ×=満たさない / —=未検証
+
+| 候補 | ネイティブウィンドウ | 起動時 cwd | 操作数 | ちらつき・レース | 既存整合 | 保守性 | 総合 |
+|------|---------------------|-----------|--------|-----------------|----------|--------|------|
+| **A** default-path + async_create_window | — | — | — | — | ×（tmux 3.6 で不可） | × | **不可** |
+| **B** send-keys cd | ○ | × | 2 | △（cd 未反映） | ×（#9 要件外） | △ | **不可** |
+| **C** Profile API (LocalWriteOnlyProfile) | △ | × | 2 | — | × | △ | **不可** |
+| **D** new-window -c | ×（タブ） | ○ | 1 | ○ | ×（#15 デグレ） | ○ | **cwd のみ可** |
+| **baseline** async_create_window + respawn-pane | ○ | ○ | 2〜3 | △（pane 再起動） | ○ | △ | **採用** |
+
+### 候補別詳細
+
+#### A. `default-path` + `async_create_window()`
+
+- `tmux set-option default-path` → **`invalid option: default-path`**（tmux 3.6a）
+- tmux 1.9 以降削除済み。Issue 本文の候補 A は **現行 tmux では実行不能**
+- 仮に存在しても `async_create_window()` が tmux `-c` を渡せない根本問題は残る
+
+#### B. 作成後 `send-keys` で `cd`
+
+実機（`async_create_window` 経路、`async_activate` 後）:
+
+```json
+{
+  "native_window": true,
+  "startup_cwd_match": false,
+  "pane_path": "/private/tmp/issue17-cwd-a",
+  "expected_path": "/private/tmp/issue17-cwd-b"
+}
+```
+
+- `send-keys` による `cd` が **pane に反映されない**（view-mode / CC フロー制御の影響疑い）
+- たとえ cd できても **起動後 cd** であり #9 の「起動時 cwd」要件を満たさない
+- tmux-resurrect との整合も劣る
+
+#### C. Session / Profile API
+
+実機:
+
+```json
+{
+  "native_window": false,
+  "startup_cwd_match": false,
+  "pane_path": "/private/tmp/issue17-cwd-a"
+}
+```
+
+- `LocalWriteOnlyProfile.set_custom_directory` は **新規セッション起動時**の initial directory 用
+- `Session.async_set_profile_properties` は **実行中 pane の cwd を変更しない**（プロファイルコピーのみ）
+- `TmuxConnection.async_create_window()` は `profile_customizations` を受け取れない
+
+#### D. `new-window -c` + 経路切り分け
+
+| 経路 | ネイティブ | 起動 cwd | 備考 |
+|------|-----------|---------|------|
+| `async_send_command("new-window -c")` | × | ○ | iTerm window 15820 の tab 1→2 に追加 |
+| `subprocess tmux new-window -c` | × | ○ | API 経路と同一結果 |
+| `itmux add`（現 bridge.py cwd 分岐） | × | ○ | tab 追加を確認 |
+
+- iTerm2 設定 `NoSyncNewWindowFromTmuxOpensTmux=0` でも CC 下の `new-window -c` はタブ化
+- **cwd だけ必要なら D は最良**だが、#15 で棄却された「タブ化デグレ」が再発
+
+#### baseline. PR #16（`async_create_window` + `respawn-pane -c -k`）
+
+実機:
+
+```json
+{
+  "native_window": true,
+  "startup_cwd_match": true,
+  "pane_path": "/private/tmp/issue17-cwd-a"
+}
+```
+
+- ネイティブウィンドウ + 起動 cwd を**同時に満たす唯一の経路**
+- `-k` による pane 再起動で短いちらつき・レース余地あり（#14 で許容されたトレードオフ）
+- `async_activate` による view-mode 防止と併用（既存 bridge.py）
+
+## E. 上流機能要望の要否
+
+| 観点 | 判断 |
+|------|------|
+| 要否 | **推奨する**（ただし iTmux 単独では実装不可） |
+| 内容 | `TmuxRequest.CreateWindow` に `start_directory`（または tmux `-c` 相当）を追加 |
+| 期待効果 | `respawn-pane -k` 不要化、操作 1 回化、ちらつき低減 |
+| 優先度 | 中 — 現行 workaround は動作するが、設計上の歪みが残る |
+| 代替 | 上流対応まで PR #16 方針を正とする |
+
+## なぜ `respawn-pane` が現実解か（制約の整理）
+
+1. **ネイティブウィンドウ作成**は iTerm2 RPC `async_create_window()` のみが確実（`new-window -c` はタブ）
+2. **起動時 cwd**は tmux `-c` 付き window/pane 作成が必要（`send-keys cd` は要件外かつ CC 下で不安定）
+3. **API に cwd 引数がない**ため、window 作成後に `respawn-pane -c -k` で pane を `-c` 相当に作り直すのが唯一の橋渡し
+4. **`default-path` は使えない**（tmux 1.9+ 削除）
+5. **Profile API は tmux pane 起動後には cwd を変えられない**
+
+## 実装方針（本 Issue スコープ外・参考）
+
+- **採用**: PR #16 方針を維持（#15 マージ後の正本）
+- **リスク**: respawn ちらつき、view-mode レース（`async_activate` + sleep で緩和済み）
+- **フォロー**: iTerm2 upstream に `CreateWindow.start_directory` 要望。対応後は respawn 経路を削除可能
+
+## 再現手順
+
+```bash
+# 1. テスト用 config
+export ITMUX_CONFIG_PATH=/path/to/config.json  # cwd 付き project 定義
+
+# 2. CC attach
+itmux open issue17-test
+
+# 3. シェルベース（D 系）
+scripts/research/issue17_cwd_shell_test.sh issue17-test
+
+# 4. API ベース（baseline / B / C）— iTerm2 内で venv python 実行
+.venv/bin/python scripts/research/issue17_async_create_test.py issue17-test
+.venv/bin/python scripts/research/issue17_bc_test.py issue17-test
+```
+
+結果 JSON: `/tmp/issue17-cwd-shell-results.json`, `/tmp/issue17-async-create-results.json`, `/tmp/issue17-bc-results.json`
+
+## 未検証・保留
+
+- iTerm2 設定「Open tmux windows as native tabs in a new window」を **全組み合わせ**で網羅したマトリクス（代表環境では `new-window -c` はいずれもタブ）
+- 候補 C を **window 作成前**に Profile を注入する経路（API 上存在しない）
+- マルチモニタ / `window_size` 復元との組み合わせ（respawn 後の resize は既存 `set_window_size` で対応、追加検証は任意）
+
+## 関連
+
+- #15 / PR #16 — 暫定 respawn-pane 解
+- #9 — 起動時 cwd 要件
+- #14 — respawn 方針
+- `docs/ARCHITECTURE.md` cwd 節（PR #16 マージ後に更新予定）

--- a/scripts/research/issue17_async_create_test.py
+++ b/scripts/research/issue17_async_create_test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Minimal async_create_window + respawn-pane test for Issue #17."""
+import asyncio
+import json
+import shlex
+import sys
+from pathlib import Path
+
+import iterm2
+
+SESSION = sys.argv[1] if len(sys.argv) > 1 else "issue17-test"
+CWD = Path("/tmp/issue17-cwd-a")
+OUT = Path("/tmp/issue17-async-create-results.json")
+
+
+async def main(connection):
+    app = await iterm2.async_get_app(connection)
+    tmux_conn = None
+    for conn in await iterm2.async_get_tmux_connections(connection):
+        name = (await conn.async_send_command("display-message -p '#{session_name}'")).strip()
+        if name == SESSION:
+            tmux_conn = conn
+            break
+    if not tmux_conn:
+        raise RuntimeError(f"No CC connection for {SESSION}")
+
+    windows_before = len(app.windows)
+    tab_counts = {w.window_id: len(w.tabs) for w in app.windows}
+
+    w = await tmux_conn.async_create_window()
+    await asyncio.sleep(0.15)
+    windows_after = len(app.windows)
+    native = windows_after > windows_before
+
+    tab = w.current_tab
+    wid = str(tab.tmux_window_id).lstrip("@")
+    path = shlex.quote(str(CWD))
+    await tmux_conn.async_send_command(f"respawn-pane -t @{wid} -c {path} -k")
+    await asyncio.sleep(0.15)
+    pane_path = (
+        await tmux_conn.async_send_command(
+            f"display-message -t @{wid} -p '#{{pane_current_path}}'"
+        )
+    ).strip()
+
+    await tmux_conn.async_send_command(f"kill-window -t @{wid}")
+
+    result = {
+        "method": "async_create_window + respawn-pane -c -k",
+        "native_window": native,
+        "startup_cwd_match": Path(pane_path).resolve() == CWD.resolve(),
+        "pane_path": pane_path,
+        "expected_path": str(CWD.resolve()),
+        "operation_count": 3,
+    }
+    OUT.write_text(json.dumps(result, indent=2))
+    print(json.dumps(result, indent=2))
+
+
+iterm2.run_until_complete(main)

--- a/scripts/research/issue17_b_retest.py
+++ b/scripts/research/issue17_b_retest.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Re-test B with async_activate (view-mode mitigation)."""
+import asyncio
+import json
+import shlex
+import sys
+from pathlib import Path
+
+import iterm2
+
+SESSION = sys.argv[1] if len(sys.argv) > 1 else "issue17-test"
+OUT = Path("/tmp/issue17-b-retest.json")
+
+
+async def main(connection):
+    app = await iterm2.async_get_app(connection)
+    tmux_conn = None
+    for conn in await iterm2.async_get_tmux_connections(connection):
+        name = (await conn.async_send_command("display-message -p '#{session_name}'")).strip()
+        if name == SESSION:
+            tmux_conn = conn
+            break
+    cwd = Path("/tmp/issue17-cwd-b")
+    w_before = len(app.windows)
+    w = await tmux_conn.async_create_window()
+    await asyncio.sleep(0.05)
+    await w.async_activate()
+    await asyncio.sleep(0.05)
+    native = len(app.windows) > w_before
+    wid = str(w.current_tab.tmux_window_id).lstrip("@")
+    path = shlex.quote(str(cwd))
+    await tmux_conn.async_send_command(f"send-keys -t @{wid} 'cd {path}' Enter")
+    await asyncio.sleep(0.4)
+    pp = (
+        await tmux_conn.async_send_command(
+            f"display-message -t @{wid} -p '#{{pane_current_path}}'"
+        )
+    ).strip()
+    await tmux_conn.async_send_command(f"kill-window -t @{wid}")
+    result = {
+        "candidate": "B-retest",
+        "native_window": native,
+        "startup_cwd_match": Path(pp).resolve() == cwd.resolve(),
+        "pane_path": pp,
+        "expected_path": str(cwd.resolve()),
+        "notes": ["async_activate before send-keys; still post-start cd"],
+    }
+    OUT.write_text(json.dumps(result, indent=2))
+    print(json.dumps(result, indent=2))
+
+
+iterm2.run_until_complete(main)

--- a/scripts/research/issue17_bc_test.py
+++ b/scripts/research/issue17_bc_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Test candidates B and C on async_create_window path."""
+import asyncio
+import json
+import shlex
+import sys
+from pathlib import Path
+
+import iterm2
+from iterm2.profile import InitialWorkingDirectory, LocalWriteOnlyProfile
+
+SESSION = sys.argv[1] if len(sys.argv) > 1 else "issue17-test"
+OUT = Path("/tmp/issue17-bc-results.json")
+
+
+async def get_conn(connection, session):
+    for conn in await iterm2.async_get_tmux_connections(connection):
+        name = (await conn.async_send_command("display-message -p '#{session_name}'")).strip()
+        if name == session:
+            return conn
+    raise RuntimeError("no conn")
+
+
+async def pane_path(tmux_conn, wid):
+    return (
+        await tmux_conn.async_send_command(
+            f"display-message -t @{wid} -p '#{{pane_current_path}}'"
+        )
+    ).strip()
+
+
+async def test_b(tmux_conn, app, cwd):
+    w_before = len(app.windows)
+    w = await tmux_conn.async_create_window()
+    await asyncio.sleep(0.1)
+    native = len(app.windows) > w_before
+    wid = str(w.current_tab.tmux_window_id).lstrip("@")
+    path = shlex.quote(str(cwd))
+    await tmux_conn.async_send_command(f"send-keys -t @{wid} 'cd {path}' Enter")
+    await asyncio.sleep(0.25)
+    pp = await pane_path(tmux_conn, wid)
+    await tmux_conn.async_send_command(f"kill-window -t @{wid}")
+    return {
+        "candidate": "B",
+        "native_window": native,
+        "startup_cwd_match": Path(pp).resolve() == cwd.resolve(),
+        "pane_path": pp,
+        "expected_path": str(cwd.resolve()),
+    }
+
+
+async def test_c(tmux_conn, app, cwd):
+    w_before = len(app.windows)
+    w = await tmux_conn.async_create_window()
+    await asyncio.sleep(0.1)
+    native = len(app.windows) > w_before
+    wid = str(w.current_tab.tmux_window_id).lstrip("@")
+    session = w.current_tab.current_session
+    lwop = LocalWriteOnlyProfile()
+    lwop.set_initial_directory_mode(
+        InitialWorkingDirectory.INITIAL_WORKING_DIRECTORY_CUSTOM
+    )
+    lwop.set_custom_directory(str(cwd))
+    await session.async_set_profile_properties(lwop)
+    await asyncio.sleep(0.1)
+    pp = await pane_path(tmux_conn, wid)
+    await tmux_conn.async_send_command(f"kill-window -t @{wid}")
+    return {
+        "candidate": "C",
+        "native_window": native,
+        "startup_cwd_match": Path(pp).resolve() == cwd.resolve(),
+        "pane_path": pp,
+        "expected_path": str(cwd.resolve()),
+    }
+
+
+async def main(connection):
+    app = await iterm2.async_get_app(connection)
+    tmux_conn = await get_conn(connection, SESSION)
+    results = [
+        await test_b(tmux_conn, app, Path("/tmp/issue17-cwd-b")),
+        await test_c(tmux_conn, app, Path("/tmp/issue17-cwd-c")),
+    ]
+    OUT.write_text(json.dumps(results, indent=2))
+    print(json.dumps(results, indent=2))
+
+
+iterm2.run_until_complete(main)

--- a/scripts/research/issue17_cwd_candidates.py
+++ b/scripts/research/issue17_cwd_candidates.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Issue #17: attach 後の追加ウィンドウ cwd 候補 A〜D の実機検証.
+
+Usage (iTerm2 内):
+  /Applications/iTerm.app/Contents/Resources/it2run \\
+    scripts/research/issue17_cwd_candidates.py [session_name]
+
+Results are written to /tmp/issue17-cwd-results.json
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import iterm2
+from iterm2.profile import InitialWorkingDirectory, LocalWriteOnlyProfile
+
+SESSION_NAME = sys.argv[1] if len(sys.argv) > 1 else "e2e-test-project"
+RESULT_PATH = Path("/tmp/issue17-cwd-results.json")
+
+CWD_PATHS = {
+    "A": Path("/tmp/issue17-cwd-a"),
+    "B": Path("/tmp/issue17-cwd-b"),
+    "C": Path("/tmp/issue17-cwd-c"),
+    "D": Path("/tmp/issue17-cwd-d"),
+    "baseline": Path("/tmp/issue17-cwd-a"),
+}
+
+
+@dataclass
+class CandidateResult:
+    candidate: str
+    native_window: Optional[bool] = None
+    startup_cwd_match: Optional[bool] = None
+    pane_path: Optional[str] = None
+    expected_path: Optional[str] = None
+    operation_count: int = 0
+    notes: list[str] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+def count_iterm_windows(app: iterm2.App) -> int:
+    return len(app.windows)
+
+
+def window_has_single_tab(window: iterm2.Window) -> bool:
+    return len(window.tabs) == 1
+
+
+async def get_tmux_conn(
+    connection: iterm2.Connection, session_name: str
+) -> tuple[iterm2.TmuxConnection, iterm2.App]:
+    app = await iterm2.async_get_app(connection)
+    for conn in await iterm2.async_get_tmux_connections(connection):
+        result = await conn.async_send_command("display-message -p '#{session_name}'")
+        if result.strip() == session_name:
+            return conn, app
+    raise RuntimeError(
+        f"No Control Mode connection for session {session_name!r}. "
+        f"Attach with: tmux -CC attach -t {session_name}"
+    )
+
+
+async def pane_current_path(tmux_conn: iterm2.TmuxConnection, tmux_window_id: str) -> str:
+    wid = tmux_window_id.lstrip("@")
+    result = await tmux_conn.async_send_command(
+        f"display-message -t @{wid} -p '#{{pane_current_path}}'"
+    )
+    return result.strip()
+
+
+async def kill_test_window(tmux_conn: iterm2.TmuxConnection, tmux_window_id: str) -> None:
+    wid = tmux_window_id.lstrip("@")
+    await tmux_conn.async_send_command(f"kill-window -t @{wid}")
+
+
+async def observe_window_creation(
+    app: iterm2.App,
+    tmux_conn: iterm2.TmuxConnection,
+    create_fn,
+) -> tuple[iterm2.Window, str, int, bool]:
+    """Returns (window, tmux_window_id, op_count, native_window)."""
+    windows_before = count_iterm_windows(app)
+    tab_counts_before = {w.window_id: len(w.tabs) for w in app.windows}
+    op_count = 0
+
+    iterm_window = await create_fn()
+    op_count += 1
+    await asyncio.sleep(0.15)
+
+    windows_after = count_iterm_windows(app)
+    native_window = windows_after > windows_before
+
+    if not native_window:
+        for w in app.windows:
+            before = tab_counts_before.get(w.window_id, 0)
+            if len(w.tabs) > before:
+                iterm_window = w
+                break
+
+    tab = iterm_window.current_tab
+    tmux_window_id = str(tab.tmux_window_id) if tab.tmux_window_id else ""
+    return iterm_window, tmux_window_id, op_count, native_window
+
+
+async def test_a(tmux_conn, app, session_name, cwd) -> CandidateResult:
+    result = CandidateResult("A", expected_path=str(cwd.resolve()))
+    try:
+        quoted = shlex.quote(str(cwd))
+        await tmux_conn.async_send_command(
+            f"set-option -t {session_name} default-path {quoted}"
+        )
+        result.operation_count += 1
+
+        async def create():
+            return await tmux_conn.async_create_window()
+
+        window, wid, ops, native = await observe_window_creation(
+            app, tmux_conn, create
+        )
+        result.operation_count += ops
+        result.native_window = native
+        result.pane_path = await pane_current_path(tmux_conn, wid)
+        result.startup_cwd_match = result.pane_path == result.expected_path
+        if not result.startup_cwd_match:
+            result.notes.append("default-path did not apply to async_create_window()")
+        await kill_test_window(tmux_conn, wid)
+        result.operation_count += 1
+        await tmux_conn.async_send_command(
+            f"set-option -t {session_name} default-path ~"
+        )
+        result.operation_count += 1
+    except Exception as exc:
+        result.error = str(exc)
+    return result
+
+
+async def test_b(tmux_conn, app, session_name, cwd) -> CandidateResult:
+    result = CandidateResult("B", expected_path=str(cwd.resolve()))
+    try:
+
+        async def create():
+            return await tmux_conn.async_create_window()
+
+        window, wid, ops, native = await observe_window_creation(
+            app, tmux_conn, create
+        )
+        result.operation_count += ops
+        result.native_window = native
+        path = shlex.quote(str(cwd))
+        await tmux_conn.async_send_command(
+            f"send-keys -t @{wid.lstrip('@')} 'cd {path}' Enter"
+        )
+        result.operation_count += 1
+        await asyncio.sleep(0.2)
+        result.pane_path = await pane_current_path(tmux_conn, wid)
+        result.startup_cwd_match = result.pane_path == result.expected_path
+        result.notes.append("post-start cd; does not satisfy startup cwd requirement")
+        await kill_test_window(tmux_conn, wid)
+        result.operation_count += 1
+    except Exception as exc:
+        result.error = str(exc)
+    return result
+
+
+async def test_c(tmux_conn, app, session_name, cwd) -> CandidateResult:
+    result = CandidateResult("C", expected_path=str(cwd.resolve()))
+    try:
+
+        async def create():
+            return await tmux_conn.async_create_window()
+
+        window, wid, ops, native = await observe_window_creation(
+            app, tmux_conn, create
+        )
+        result.operation_count += ops
+        result.native_window = native
+        session = window.current_tab.current_session
+        lwop = LocalWriteOnlyProfile()
+        lwop.set_initial_directory_mode(
+            InitialWorkingDirectory.INITIAL_WORKING_DIRECTORY_CUSTOM
+        )
+        lwop.set_custom_directory(str(cwd))
+        await session.async_set_profile_properties(lwop)
+        result.operation_count += 1
+        await asyncio.sleep(0.1)
+        result.pane_path = await pane_current_path(tmux_conn, wid)
+        result.startup_cwd_match = result.pane_path == result.expected_path
+        result.notes.append(
+            "async_set_profile_properties on running tmux pane; no respawn"
+        )
+        await kill_test_window(tmux_conn, wid)
+        result.operation_count += 1
+    except Exception as exc:
+        result.error = str(exc)
+    return result
+
+
+async def test_d_api(tmux_conn, app, session_name, cwd) -> CandidateResult:
+    result = CandidateResult("D-api", expected_path=str(cwd.resolve()))
+    try:
+        path = shlex.quote(str(cwd))
+
+        async def create():
+            await tmux_conn.async_send_command(
+                f"new-window -t {session_name} -c {path}"
+            )
+            await asyncio.sleep(0.05)
+            matched = []
+            for w in app.windows:
+                for tab in w.tabs:
+                    if tab.tmux_connection_id != tmux_conn.connection_id:
+                        continue
+                    twid = str(tab.tmux_window_id) if tab.tmux_window_id else None
+                    if twid:
+                        matched.append(w)
+                        break
+            if not matched:
+                raise RuntimeError("window not found after new-window -c")
+            matched.sort(key=lambda w: w.window_id)
+            return matched[-1]
+
+        window, wid, ops, native = await observe_window_creation(
+            app, tmux_conn, create
+        )
+        result.operation_count += ops + 1
+        result.native_window = native
+        result.pane_path = await pane_current_path(tmux_conn, wid)
+        result.startup_cwd_match = result.pane_path == result.expected_path
+        result.notes.append("async_send_command new-window -c")
+        await kill_test_window(tmux_conn, wid)
+        result.operation_count += 1
+    except Exception as exc:
+        result.error = str(exc)
+    return result
+
+
+async def test_d_subprocess(
+    tmux_conn, app, session_name, cwd
+) -> CandidateResult:
+    result = CandidateResult("D-subprocess", expected_path=str(cwd.resolve()))
+    try:
+        windows_before = count_iterm_windows(app)
+        tab_counts_before = {w.window_id: len(w.tabs) for w in app.windows}
+        subprocess.run(
+            ["tmux", "new-window", "-t", session_name, "-c", str(cwd)],
+            check=True,
+            capture_output=True,
+        )
+        result.operation_count += 1
+        await asyncio.sleep(0.15)
+        windows_after = count_iterm_windows(app)
+        result.native_window = windows_after > windows_before
+        iterm_window = None
+        wid = ""
+        if not result.native_window:
+            for w in app.windows:
+                before = tab_counts_before.get(w.window_id, 0)
+                if len(w.tabs) > before:
+                    iterm_window = w
+                    break
+        else:
+            new_windows = [w for w in app.windows if w.window_id not in tab_counts_before]
+            if new_windows:
+                iterm_window = new_windows[-1]
+        if iterm_window is None:
+            raise RuntimeError("window not found after subprocess new-window -c")
+        wid = str(iterm_window.current_tab.tmux_window_id)
+        result.pane_path = await pane_current_path(tmux_conn, wid)
+        result.startup_cwd_match = result.pane_path == result.expected_path
+        result.notes.append("subprocess tmux new-window -c")
+        await kill_test_window(tmux_conn, wid)
+        result.operation_count += 1
+    except Exception as exc:
+        result.error = str(exc)
+    return result
+
+
+async def test_baseline(tmux_conn, app, session_name, cwd) -> CandidateResult:
+    result = CandidateResult("baseline(PR#16)", expected_path=str(cwd.resolve()))
+    try:
+
+        async def create():
+            w = await tmux_conn.async_create_window()
+            tab = w.current_tab
+            wid = str(tab.tmux_window_id).lstrip("@")
+            path = shlex.quote(str(cwd))
+            await tmux_conn.async_send_command(
+                f"respawn-pane -t @{wid} -c {path} -k"
+            )
+            await asyncio.sleep(0.1)
+            return w
+
+        window, wid, ops, native = await observe_window_creation(
+            app, tmux_conn, create
+        )
+        result.operation_count += ops + 1
+        result.native_window = native
+        result.pane_path = await pane_current_path(tmux_conn, wid)
+        result.startup_cwd_match = result.pane_path == result.expected_path
+        result.notes.append("async_create_window + respawn-pane -c -k")
+        await kill_test_window(tmux_conn, wid)
+        result.operation_count += 1
+    except Exception as exc:
+        result.error = str(exc)
+    return result
+
+
+async def main(connection: iterm2.Connection) -> None:
+    tmux_conn, app = await get_tmux_conn(connection, SESSION_NAME)
+    results: list[CandidateResult] = []
+
+    tests = [
+        ("A", test_a, "A"),
+        ("B", test_b, "B"),
+        ("C", test_c, "C"),
+        ("D-api", test_d_api, "D"),
+        ("D-subprocess", test_d_subprocess, "D"),
+        ("baseline(PR#16)", test_baseline, "baseline"),
+    ]
+    for _name, fn, cwd_key in tests:
+        cwd = CWD_PATHS[cwd_key]
+        r = await fn(tmux_conn, app, SESSION_NAME, cwd)
+        results.append(r)
+        await asyncio.sleep(0.2)
+
+    payload: dict[str, Any] = {
+        "session": SESSION_NAME,
+        "iterm2_version": iterm2.__version__,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "results": [asdict(r) for r in results],
+    }
+    RESULT_PATH.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+iterm2.run_until_complete(main)

--- a/scripts/research/issue17_cwd_shell_test.sh
+++ b/scripts/research/issue17_cwd_shell_test.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Issue #17: attach 後 cwd 候補の実機検証（tmux + AppleScript）
+# Control Mode attach 済みセッションで実行すること。
+set -euo pipefail
+
+SESSION="${1:-iTmux}"
+RESULT="/tmp/issue17-cwd-shell-results.json"
+
+CWD_A="/tmp/issue17-cwd-a"
+CWD_B="/tmp/issue17-cwd-b"
+CWD_C="/tmp/issue17-cwd-c"
+CWD_D="/tmp/issue17-cwd-d"
+
+count_iterm_windows() {
+  osascript -e 'tell application "iTerm2" to count windows'
+}
+
+count_session_tabs_in_any_window() {
+  local conn_id="$1"
+  osascript <<EOF
+tell application "iTerm2"
+  set tabCount to 0
+  repeat with w in windows
+    repeat with t in tabs of w
+      try
+        if (tmux connection id of t as text) contains "$conn_id" then
+          set tabCount to tabCount + 1
+        end if
+      end try
+    end repeat
+  end repeat
+  return tabCount
+end tell
+EOF
+}
+
+pane_path() {
+  local target="$1"
+  tmux display-message -t "$target" -p '#{pane_current_path}'
+}
+
+latest_window_target() {
+  tmux list-windows -t "$SESSION" -F '#{window_id}' | tail -1
+}
+
+kill_latest_test_window() {
+  local wid
+  wid=$(tmux list-windows -t "$SESSION" -F '#{window_id}' | tail -1)
+  tmux kill-window -t "$wid" 2>/dev/null || true
+}
+
+record() {
+  python3 - "$@" <<'PY'
+import json, sys
+from pathlib import Path
+path = Path("/tmp/issue17-cwd-shell-results.json")
+data = json.loads(path.read_text()) if path.exists() else {"session": sys.argv[1], "results": []}
+entry = json.loads(sys.argv[2])
+data["results"].append(entry)
+path.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+PY
+}
+
+init_json() {
+  python3 - <<PY
+import json, time
+from pathlib import Path
+Path("$RESULT").write_text(json.dumps({
+  "session": "$SESSION",
+  "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+  "results": []
+}, indent=2))
+PY
+}
+
+require_cc() {
+  if ! tmux list-clients -t "$SESSION" 2>/dev/null | grep -q control-mode; then
+    echo "Session $SESSION is not attached via Control Mode" >&2
+    exit 1
+  fi
+}
+
+require_cc
+init_json
+
+WINDOWS_BEFORE=$(count_iterm_windows)
+
+# --- A: default-path + new-window (removed in tmux >=1.9) ---
+echo "Testing A..."
+if tmux set-option -t "$SESSION" default-path "$CWD_A" 2>/dev/null; then
+  W_BEFORE=$(count_iterm_windows)
+  tmux new-window -t "$SESSION"
+  sleep 0.2
+  W_AFTER=$(count_iterm_windows)
+  WID=$(latest_window_target)
+  PATH_A=$(pane_path "@${WID#@}")
+  record "$SESSION" "$(python3 - <<EOF
+import json
+print(json.dumps({
+  "candidate": "A",
+  "method": "set-option default-path + tmux new-window",
+  "native_window": $W_AFTER > $W_BEFORE,
+  "startup_cwd_match": "$PATH_A" == "$CWD_A",
+  "pane_path": "$PATH_A",
+  "expected_path": "$CWD_A",
+  "operation_count": 2,
+  "notes": ["default-path available on this tmux version"]
+}))
+EOF
+)"
+  kill_latest_test_window
+  tmux set-option -t "$SESSION" default-path ~
+else
+  record "$SESSION" "$(python3 - <<'EOF'
+import json
+print(json.dumps({
+  "candidate": "A",
+  "method": "set-option default-path + async_create_window (planned)",
+  "native_window": None,
+  "startup_cwd_match": None,
+  "pane_path": None,
+  "expected_path": "/tmp/issue17-cwd-a",
+  "operation_count": 0,
+  "error": "invalid option: default-path (removed in tmux 1.9; unavailable on tmux 3.6a)",
+  "notes": ["Issue body candidate A is obsolete for modern tmux", "async_create_window cannot receive -c; no default-path fallback"]
+}))
+EOF
+)"
+fi
+
+# --- B: new-window + send-keys cd ---
+echo "Testing B..."
+W_BEFORE=$(count_iterm_windows)
+tmux new-window -t "$SESSION"
+sleep 0.1
+WID=$(latest_window_target)
+tmux send-keys -t "@${WID#@}" "cd $CWD_B" Enter
+sleep 0.2
+W_AFTER=$(count_iterm_windows)
+PATH_B=$(pane_path "@${WID#@}")
+record "$SESSION" "$(python3 - <<EOF
+import json
+print(json.dumps({
+  "candidate": "B",
+  "method": "new-window + send-keys cd",
+  "native_window": $W_AFTER > $W_BEFORE,
+  "startup_cwd_match": "$PATH_B" == "$CWD_B",
+  "pane_path": "$PATH_B",
+  "expected_path": "$CWD_B",
+  "operation_count": 3,
+  "notes": ["post-start cd; fails startup cwd requirement by design"]
+}))
+EOF
+)"
+kill_latest_test_window
+
+# --- D-api: new-window -c via tmux (same as async_send_command) ---
+echo "Testing D-api..."
+W_BEFORE=$(count_iterm_windows)
+tmux new-window -t "$SESSION" -c "$CWD_D"
+sleep 0.2
+W_AFTER=$(count_iterm_windows)
+WID=$(latest_window_target)
+PATH_D=$(pane_path "@${WID#@}")
+record "$SESSION" "$(python3 - <<EOF
+import json
+print(json.dumps({
+  "candidate": "D-api",
+  "method": "tmux new-window -c (async_send_command equivalent)",
+  "native_window": $W_AFTER > $W_BEFORE,
+  "startup_cwd_match": "$PATH_D" == "$CWD_D",
+  "pane_path": "$PATH_D",
+  "expected_path": "$CWD_D",
+  "operation_count": 1,
+  "notes": ["#15 regression: opens as tab not native window when native_window=false"]
+}))
+EOF
+)"
+kill_latest_test_window
+
+# --- D-subprocess: same command, verify identical ---
+echo "Testing D-subprocess..."
+W_BEFORE=$(count_iterm_windows)
+/usr/bin/env tmux new-window -t "$SESSION" -c "$CWD_D"
+sleep 0.2
+W_AFTER=$(count_iterm_windows)
+WID=$(latest_window_target)
+PATH_DS=$(pane_path "@${WID#@}")
+record "$SESSION" "$(python3 - <<EOF
+import json
+print(json.dumps({
+  "candidate": "D-subprocess",
+  "method": "subprocess tmux new-window -c",
+  "native_window": $W_AFTER > $W_BEFORE,
+  "startup_cwd_match": "$PATH_DS" == "$CWD_D",
+  "pane_path": "$PATH_DS",
+  "expected_path": "$CWD_D",
+  "operation_count": 1,
+  "notes": ["identical to D-api in this environment"]
+}))
+EOF
+)"
+kill_latest_test_window
+
+# --- baseline: new-window + respawn-pane -c -k (proxy without async_create_window) ---
+echo "Testing baseline..."
+W_BEFORE=$(count_iterm_windows)
+tmux new-window -t "$SESSION"
+sleep 0.1
+WID=$(latest_window_target)
+tmux respawn-pane -t "@${WID#@}" -c "$CWD_A" -k
+sleep 0.2
+W_AFTER=$(count_iterm_windows)
+PATH_BASE=$(pane_path "@${WID#@}")
+record "$SESSION" "$(python3 - <<EOF
+import json
+print(json.dumps({
+  "candidate": "baseline(PR#16-proxy)",
+  "method": "new-window + respawn-pane -c -k",
+  "native_window": $W_AFTER > $W_BEFORE,
+  "startup_cwd_match": "$PATH_BASE" == "$CWD_A",
+  "pane_path": "$PATH_BASE",
+  "expected_path": "$CWD_A",
+  "operation_count": 2,
+  "notes": ["respawn-pane proxy; async_create_window gives native window per #15"]
+}))
+EOF
+)"
+kill_latest_test_window
+
+# --- async_create_window native check via documented behavior ---
+# Compare: plain new-window under CC vs async_create_window from #15
+W_BEFORE=$(count_iterm_windows)
+tmux new-window -t "$SESSION"
+sleep 0.2
+W_AFTER=$(count_iterm_windows)
+NEW_WIN_NATIVE=$([[ "$W_AFTER" -gt "$W_BEFORE" ]] && echo True || echo False)
+kill_latest_test_window
+
+python3 - <<PY
+import json
+from pathlib import Path
+p = Path("$RESULT")
+data = json.loads(p.read_text())
+data["tmux_new_window_under_cc_native"] = $NEW_WIN_NATIVE
+data["iterm_windows_at_start"] = $WINDOWS_BEFORE
+p.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+print(p.read_text())
+PY


### PR DESCRIPTION
## Summary

- attach 済み Control Mode 下で、候補 A〜D を実機検証し、評価軸に沿った結果表を Issue #17 に投稿
- iterm2 2.20（PyPI 最新）および upstream `api.proto` を調査し、`async_create_window` に cwd 引数が無いことを確認
- **結論**: PR #16 の `async_create_window` + `respawn-pane -c -k` が唯一の実用解。上流への `CreateWindow.start_directory` 要望を推奨

## 受け入れ条件との対応

| 条件 | 対応 |
|------|------|
| 候補 A〜D 実機試行 + 結果表 | Issue コメント + 本レポート §候補評価結果表 |
| respawn より優れる案の方針 | 見つからず — PR #16 維持を推奨（§結論） |
| respawn が現実解である理由 | §なぜ respawn-pane が現実解か |
| 上流要望（E）の要否 | 推奨（§E） |
| iterm2 新バージョン調査 | §iterm2 ライブラリ版調査 |

## Test plan

- [x] 実機: `issue17-test` CC セッションで A〜D / baseline 検証
- [x] 実機: `itmux add` で D 経路（new-window -c）のタブ化 + cwd 確認
- [x] 実機: `async_create_window` + `respawn-pane` baseline 確認
- [x] 静的: iterm2 2.20 ソース + upstream api.proto 確認
- [ ] 手動: iTerm2 tmux 設定マトリクス全組み合わせ（代表環境のみ、未検証と明記）

Closes #17

Made with [Cursor](https://cursor.com)