### PR TITLE
fix: sync 時にユーザー設定済みプロジェクトを削除しない (#19)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -233,7 +233,12 @@ set-environment -g PATH "/opt/homebrew/bin:$PATH"
 2. sync --all の場合（全プロジェクトチェック）
    for project_name in config.list_projects():
      if not tmux has-session -t project_name:
-       config.delete_project(project_name)
+       if project has user metadata (cwd, environments, description, etc.):
+         # ユーザー設定を保持し tmux_windows を空にクリア
+         config.update_project(project_name, [])
+       else:
+         # ウィンドウ定義のみの一時プロジェクト → 削除（後方互換）
+         config.delete_project(project_name)
    return
 
 3. プロジェクト名決定（単一プロジェクト同期の場合）
@@ -241,8 +246,7 @@ set-environment -g PATH "/opt/homebrew/bin:$PATH"
 
 4. tmuxセッション存在確認
    if not tmux has-session -t project_name:
-     # セッション終了 → プロジェクトを削除
-     config.delete_project(project_name)
+     # sync --all と同じ判定（ユーザー設定あり → tmux_windows クリア、なし → 削除）
      return
 
 5. tmuxからウィンドウリスト取得（iTerm2 API不使用）
@@ -671,10 +675,13 @@ set-hook -g session-closed "run-shell -b '{itmux_command} sync --all'"
 
 **sync --allの動作：**
 ```python
-# 全プロジェクトをチェックして、セッションが存在しないものを削除
+# 全プロジェクトをチェック。セッション不在時はユーザー設定の有無で分岐
 for project_name in config.list_projects():
     if not tmux_has_session(project_name):
-        config.delete_project(project_name)
+        if has_user_defined_metadata(project):
+            config.update_project(project_name, [])  # tmux_windows をクリア
+        else:
+            config.delete_project(project_name)
 ```
 
 ### 冪等性の確保

--- a/src/itmux/orchestrator.py
+++ b/src/itmux/orchestrator.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from .config import ConfigManager
 from .iterm2 import ITerm2Bridge
-from .models import WindowConfig
+from .models import WindowConfig, ProjectConfig
 from .exceptions import ProjectNotFoundError
 from .tmux.environment import apply_session_environments
 from .tmux.cwd import validate_cwd_path
@@ -40,6 +40,49 @@ class ProjectOrchestrator:
             env=os.environ.copy()
         )
         return result.returncode == 0
+
+    _SYNC_EPHEMERAL_PROJECT_FIELDS = frozenset({"name", "tmux_windows"})
+
+    def _has_user_defined_project_metadata(self, project: ProjectConfig) -> bool:
+        """名前と tmux 由来情報以外のユーザー設定があるか判定する."""
+        for field_name in ProjectConfig.model_fields:
+            if field_name in self._SYNC_EPHEMERAL_PROJECT_FIELDS:
+                continue
+            value = getattr(project, field_name)
+            if value is None:
+                continue
+            if field_name == "environments" and not value:
+                continue
+            if field_name == "description" and not value:
+                continue
+            return True
+        return False
+
+    def _should_delete_project_on_sync(self, project: ProjectConfig) -> bool:
+        """tmux セッション不在時にプロジェクトを削除すべきか判定する."""
+        return not self._has_user_defined_project_metadata(project)
+
+    def _handle_session_absent_on_sync(self, project_name: str) -> None:
+        """tmux セッション不在時の sync 処理（削除または tmux_windows クリア）."""
+        import sys
+
+        try:
+            project = self.config.get_project(project_name)
+        except ProjectNotFoundError:
+            return
+
+        if self._should_delete_project_on_sync(project):
+            print(
+                f"[sync] Session not found, deleting project: {project_name}",
+                file=sys.stderr,
+            )
+            self.config.delete_project(project_name)
+        else:
+            print(
+                f"[sync] Session not found, preserving user metadata: {project_name}",
+                file=sys.stderr,
+            )
+            self.config.update_project(project_name, [])
 
     async def _sync_windows_from_tmux_session(self, project_name: str) -> list[WindowConfig]:
         """tmuxセッションのウィンドウ一覧を取得し、タグ付けしてconfig用リストを返す.
@@ -402,24 +445,25 @@ class ProjectOrchestrator:
     async def _sync_all_projects(self) -> None:
         """全プロジェクトの整合性をチェック（session-closed hookから呼ばれる）.
 
-        セッションが存在しないプロジェクトをconfig.jsonから削除します。
+        セッションが存在しないプロジェクトは、ユーザー設定が残っていれば
+        tmux_windows をクリアして保持し、ウィンドウ定義のみの場合は削除する。
         """
         import sys
         print(f"[sync] Checking all projects", file=sys.stderr)
 
         for proj_name in self.config.list_projects():
             if not self._tmux_has_session(proj_name):
-                print(f"[sync] Deleting project without session: {proj_name}", file=sys.stderr)
                 try:
-                    self.config.delete_project(proj_name)
+                    self._handle_session_absent_on_sync(proj_name)
                 except Exception:
                     pass
 
     async def _sync_single_project(self, project_name: Optional[str] = None) -> None:
         """単一プロジェクトの状態を同期（tmuxセッション → config.json）.
 
-        tmuxセッションが存在しない場合、プロジェクトをconfig.jsonから削除します。
-        セッションが存在する場合、ウィンドウリストをconfig.jsonに反映します。
+        tmux セッションが存在しない場合、ユーザー設定が残っていれば
+        tmux_windows をクリアして保持し、ウィンドウ定義のみの場合は削除する。
+        セッションが存在する場合、ウィンドウリストを config.json に反映する。
 
         Args:
             project_name: プロジェクト名（省略時は環境変数から取得）
@@ -435,10 +479,8 @@ class ProjectOrchestrator:
 
         # 2. tmuxセッションが存在するかチェック
         if not self._tmux_has_session(project_name):
-            # セッション終了 → プロジェクトを削除
-            print(f"[sync] Session not found, deleting project", file=sys.stderr)
             try:
-                self.config.delete_project(project_name)
+                self._handle_session_absent_on_sync(project_name)
             except Exception:
                 # プロジェクトが既に存在しない場合は無視
                 pass

--- a/tests/itmux/test_orchestrator.py
+++ b/tests/itmux/test_orchestrator.py
@@ -375,3 +375,155 @@ class TestAdd:
 
         with pytest.raises(CwdError):
             await orchestrator.add("test-project", "window-2")
+
+
+class TestSyncDataProtection:
+    """sync 時のユーザー設定保護."""
+
+    def _orchestrator(self, mock_config_manager, mock_iterm2_bridge):
+        return ProjectOrchestrator(mock_config_manager, mock_iterm2_bridge)
+
+    def _no_session(self, mock_subprocess):
+        mock_subprocess.return_value = MagicMock(returncode=1)
+
+    def test_should_delete_window_only_project(
+        self, mock_config_manager, mock_iterm2_bridge
+    ):
+        """ウィンドウ定義のみのプロジェクトは削除対象."""
+        project = ProjectConfig(
+            name="proj",
+            tmux_windows=[WindowConfig(name="editor")],
+        )
+        orchestrator = self._orchestrator(mock_config_manager, mock_iterm2_bridge)
+        assert orchestrator._should_delete_project_on_sync(project) is True
+
+    def test_should_not_delete_with_cwd(
+        self, mock_config_manager, mock_iterm2_bridge
+    ):
+        """cwd があるプロジェクトは削除しない."""
+        project = ProjectConfig(
+            name="proj",
+            cwd=Path("/tmp"),
+            tmux_windows=[WindowConfig(name="editor")],
+        )
+        orchestrator = self._orchestrator(mock_config_manager, mock_iterm2_bridge)
+        assert orchestrator._should_delete_project_on_sync(project) is False
+
+    def test_should_not_delete_with_environments(
+        self, mock_config_manager, mock_iterm2_bridge
+    ):
+        """非空 environments があるプロジェクトは削除しない."""
+        project = ProjectConfig(
+            name="proj",
+            environments={"FOO": "bar"},
+            tmux_windows=[WindowConfig(name="editor")],
+        )
+        orchestrator = self._orchestrator(mock_config_manager, mock_iterm2_bridge)
+        assert orchestrator._should_delete_project_on_sync(project) is False
+
+    def test_should_not_delete_with_description(
+        self, mock_config_manager, mock_iterm2_bridge
+    ):
+        """description があるプロジェクトは削除しない."""
+        project = ProjectConfig(
+            name="proj",
+            description="my project",
+            tmux_windows=[WindowConfig(name="editor")],
+        )
+        orchestrator = self._orchestrator(mock_config_manager, mock_iterm2_bridge)
+        assert orchestrator._should_delete_project_on_sync(project) is False
+
+    @pytest.mark.asyncio
+    async def test_sync_single_preserves_cwd_clears_windows(
+        self, mock_config_manager, mock_iterm2_bridge, mock_subprocess
+    ):
+        """セッション不在 + cwd → 削除せず tmux_windows をクリア."""
+        self._no_session(mock_subprocess)
+        project = ProjectConfig(
+            name="proj",
+            cwd=Path("/tmp"),
+            tmux_windows=[WindowConfig(name="editor")],
+        )
+        mock_config_manager.get_project.return_value = project
+
+        orchestrator = self._orchestrator(mock_config_manager, mock_iterm2_bridge)
+        await orchestrator._sync_single_project("proj")
+
+        mock_config_manager.delete_project.assert_not_called()
+        mock_config_manager.update_project.assert_called_once_with("proj", [])
+
+    @pytest.mark.asyncio
+    async def test_sync_single_preserves_environments(
+        self, mock_config_manager, mock_iterm2_bridge, mock_subprocess
+    ):
+        """セッション不在 + 非空 environments → 削除しない."""
+        self._no_session(mock_subprocess)
+        project = ProjectConfig(
+            name="proj",
+            environments={"FOO": "bar"},
+            tmux_windows=[WindowConfig(name="editor")],
+        )
+        mock_config_manager.get_project.return_value = project
+
+        orchestrator = self._orchestrator(mock_config_manager, mock_iterm2_bridge)
+        await orchestrator._sync_single_project("proj")
+
+        mock_config_manager.delete_project.assert_not_called()
+        mock_config_manager.update_project.assert_called_once_with("proj", [])
+
+    @pytest.mark.asyncio
+    async def test_sync_single_deletes_window_only_project(
+        self, mock_config_manager, mock_iterm2_bridge, mock_subprocess
+    ):
+        """セッション不在 + ウィンドウ定義のみ → 削除."""
+        self._no_session(mock_subprocess)
+        project = ProjectConfig(
+            name="proj",
+            tmux_windows=[WindowConfig(name="editor")],
+        )
+        mock_config_manager.get_project.return_value = project
+
+        orchestrator = self._orchestrator(mock_config_manager, mock_iterm2_bridge)
+        await orchestrator._sync_single_project("proj")
+
+        mock_config_manager.delete_project.assert_called_once_with("proj")
+        mock_config_manager.update_project.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_all_preserves_cwd(
+        self, mock_config_manager, mock_iterm2_bridge, mock_subprocess
+    ):
+        """sync --all: セッション不在 + cwd → 削除しない."""
+        self._no_session(mock_subprocess)
+        project = ProjectConfig(
+            name="proj",
+            cwd=Path("/tmp"),
+            tmux_windows=[WindowConfig(name="editor")],
+        )
+        mock_config_manager.list_projects.return_value = ["proj"]
+        mock_config_manager.get_project.return_value = project
+
+        orchestrator = self._orchestrator(mock_config_manager, mock_iterm2_bridge)
+        await orchestrator._sync_all_projects()
+
+        mock_config_manager.delete_project.assert_not_called()
+        mock_config_manager.update_project.assert_called_once_with("proj", [])
+
+    @pytest.mark.asyncio
+    async def test_sync_all_deletes_window_only_project(
+        self, mock_config_manager, mock_iterm2_bridge, mock_subprocess
+    ):
+        """sync --all: セッション不在 + ウィンドウ定義のみ → 削除."""
+        self._no_session(mock_subprocess)
+        project = ProjectConfig(
+            name="proj",
+            tmux_windows=[WindowConfig(name="editor")],
+        )
+        mock_config_manager.list_projects.return_value = ["proj"]
+        mock_config_manager.get_project.return_value = project
+
+        orchestrator = self._orchestrator(mock_config_manager, mock_iterm2_bridge)
+        await orchestrator._sync_all_projects()
+
+        mock_config_manager.delete_project.assert_called_once_with("proj")
+        mock_config_manager.update_project.assert_not_called()


### PR DESCRIPTION
## Summary

tmux セッション不在時の sync で、ユーザーが手動設定したメタデータ（`cwd` / `environments` / `description` 等）を持つプロジェクトを `config.json` から削除しないように変更しました。ウィンドウ定義のみの一時プロジェクトは従来どおり削除します。

- `_has_user_defined_project_metadata` / `_should_delete_project_on_sync` / `_handle_session_absent_on_sync` を追加
- `_sync_single_project` と `_sync_all_projects` の両方で共通ロジックを適用
- 保護対象: `ProjectConfig` の `name` / `tmux_windows` 以外で非空のフィールド

## 受け入れ条件との対応

| 条件 | 状態 |
|------|------|
| セッションなし + `cwd` → sync 後も残る | ✅ |
| セッションなし + 非空 `environments` → sync 後も残る | ✅ |
| ウィンドウ定義のみ → sync で削除（後方互換） | ✅ |
| `_sync_single_project` / `_sync_all_projects` 両方に同じ判定 | ✅ |
| 単体テスト追加 | ✅ |
| `docs/ARCHITECTURE.md` sync 節更新 | ✅ |

## 設計判断

- セッション不在かつ削除しない場合: `tmux_windows` を空リストにクリア（`update_project`）
- 判定は `ProjectConfig.model_fields` を走査し、将来フィールド追加にも対応

## Test plan

- [x] `uv run pytest tests/itmux/test_orchestrator.py::TestSyncDataProtection -v`（9 件）
- [x] `uv run pytest tests/ -q --ignore=tests/e2e`（132 件）
- [ ] e2e テスト（iTerm2 / tmux 実環境が必要のため未実施）

Closes #19


Made with [Cursor](https://cursor.com)