### PR TITLE
itmux add: 未オープンのプロジェクトへの追加時に分かりやすいエラーと open への誘導

### DIFF
--- a/src/itmux/cli.py
+++ b/src/itmux/cli.py
@@ -10,7 +10,13 @@ from pathlib import Path
 from .config import ConfigManager, DEFAULT_CONFIG_PATH
 from .orchestrator import ProjectOrchestrator
 from .iterm2 import ITerm2Bridge
-from .exceptions import ProjectNotFoundError, ITerm2Error, ConfigError, CwdError
+from .exceptions import (
+    ProjectNotFoundError,
+    ProjectNotOpenError,
+    ITerm2Error,
+    ConfigError,
+    CwdError,
+)
 
 
 async def get_orchestrator() -> ProjectOrchestrator:
@@ -95,6 +101,9 @@ def run_async_command(coro, success_message: str, handle_value_error: bool = Fal
             sys.exit(1)
         raise
     except ProjectNotFoundError as e:
+        click.echo(f"✗ Error: {e}", err=True)
+        sys.exit(1)
+    except ProjectNotOpenError as e:
         click.echo(f"✗ Error: {e}", err=True)
         sys.exit(1)
     except ITerm2Error as e:

--- a/src/itmux/exceptions.py
+++ b/src/itmux/exceptions.py
@@ -1,5 +1,7 @@
 """iTmux custom exceptions."""
 
+from enum import Enum
+
 
 class ConfigError(Exception):
     """設定ファイル関連エラー."""
@@ -17,6 +19,39 @@ class ProjectNotFoundError(ConfigError):
     """プロジェクトが見つからないエラー."""
 
     pass
+
+
+class ProjectNotOpenReason(Enum):
+    """プロジェクトが iTerm2 で開いていない理由."""
+
+    NOT_OPEN = "not_open"
+    TMUX_DETACHED = "tmux_detached"
+    NOT_FOUND = "not_found"
+
+
+class ProjectNotOpenError(Exception):
+    """プロジェクトが iTerm2 で開いていないエラー."""
+
+    def __init__(self, project_name: str, reason: ProjectNotOpenReason):
+        self.project_name = project_name
+        self.reason = reason
+        super().__init__(self._format_message())
+
+    def _format_message(self) -> str:
+        if self.reason is ProjectNotOpenReason.TMUX_DETACHED:
+            situation = (
+                f"プロジェクト '{self.project_name}' は tmux 上に存在しますが、"
+                f"iTerm2 で開いていません。"
+            )
+        elif self.reason is ProjectNotOpenReason.NOT_FOUND:
+            situation = f"プロジェクト '{self.project_name}' は設定に存在しません。"
+        else:
+            situation = f"プロジェクト '{self.project_name}' は iTerm2 で開いていません。"
+
+        return (
+            f"{situation}\n"
+            f"  先に次を実行してください: itmux open {self.project_name}"
+        )
 
 
 class SessionNotFoundError(ConfigError):

--- a/src/itmux/orchestrator.py
+++ b/src/itmux/orchestrator.py
@@ -8,7 +8,12 @@ from typing import Optional
 from .config import ConfigManager
 from .iterm2 import ITerm2Bridge
 from .models import WindowConfig
-from .exceptions import ProjectNotFoundError
+from .exceptions import (
+    ITerm2Error,
+    ProjectNotFoundError,
+    ProjectNotOpenError,
+    ProjectNotOpenReason,
+)
 from .tmux.environment import apply_session_environments
 from .tmux.cwd import validate_cwd_path
 
@@ -129,6 +134,38 @@ class ProjectOrchestrator:
             raise ValueError("No project specified and not running in tmux session")
 
         return project_name
+
+    async def _ensure_project_open_for_add(self, project_name: str) -> None:
+        """add 前にプロジェクトが iTerm2 で開いていることを確認.
+
+        Args:
+            project_name: プロジェクト名
+
+        Raises:
+            ProjectNotOpenError: プロジェクトが iTerm2 で開いていない
+        """
+        try:
+            await self.bridge.get_tmux_connection(project_name)
+            return
+        except ITerm2Error:
+            pass
+
+        has_tmux = self._tmux_has_session(project_name)
+
+        try:
+            self.config.get_project(project_name)
+            has_config = True
+        except ProjectNotFoundError:
+            has_config = False
+
+        if has_tmux:
+            reason = ProjectNotOpenReason.TMUX_DETACHED
+        elif has_config:
+            reason = ProjectNotOpenReason.NOT_OPEN
+        else:
+            reason = ProjectNotOpenReason.NOT_FOUND
+
+        raise ProjectNotOpenError(project_name, reason)
 
     def _generate_window_name(self, project_name: str) -> str:
         """ウィンドウ名を自動生成.
@@ -525,22 +562,26 @@ class ProjectOrchestrator:
 
         Raises:
             ProjectNotFoundError: プロジェクトが存在しない
+            ProjectNotOpenError: プロジェクトが iTerm2 で開いていない
         """
         # 1. プロジェクト名決定
         project_name = self._resolve_project_name(project_name)
 
-        # 2. ウィンドウ名決定
+        # 2. iTerm2 で開いていることを確認
+        await self._ensure_project_open_for_add(project_name)
+
+        # 3. ウィンドウ名決定
         if window_name is None:
             window_name = self._generate_window_name(project_name)
 
-        # 3. 環境変数を適用してから新規ウィンドウ作成
+        # 4. 環境変数を適用してから新規ウィンドウ作成
         project = self.config.get_project(project_name)
         if project.cwd:
             validate_cwd_path(project.cwd)
         apply_session_environments(project_name, project.environments)
         await self.bridge.add_window(project_name, window_name, cwd=project.cwd)
 
-        # 4. 状態を同期（hookも実行されるが、確実性のため明示的に呼ぶ）
+        # 5. 状態を同期（hookも実行されるが、確実性のため明示的に呼ぶ）
         # after-new-window hookが発火するが、タイミングによっては
         # user.window_name設定前にsyncが実行される可能性があるため、
         # tag_window()完了後に明示的にsyncを実行する

--- a/tests/itmux/test_cli.py
+++ b/tests/itmux/test_cli.py
@@ -6,7 +6,13 @@ from click.testing import CliRunner
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from itmux.cli import main
-from itmux.exceptions import ProjectNotFoundError, ITerm2Error, ConfigError
+from itmux.exceptions import (
+    ProjectNotFoundError,
+    ProjectNotOpenError,
+    ProjectNotOpenReason,
+    ITerm2Error,
+    ConfigError,
+)
 
 
 class TestList:
@@ -235,6 +241,68 @@ class TestAdd:
         assert result.exit_code == 0
         assert "✓ Added window to project: current" in result.output
         mock_orchestrator.add.assert_called_once_with(None, None)
+
+    def test_add_project_not_open_in_iterm2(self):
+        """iTerm2 で未オープンのプロジェクトへの追加."""
+        runner = CliRunner()
+
+        mock_orchestrator = AsyncMock()
+        mock_orchestrator.add.side_effect = ProjectNotOpenError(
+            "iTmux", ProjectNotOpenReason.NOT_OPEN
+        )
+
+        async def mock_get_orchestrator():
+            return mock_orchestrator
+
+        with patch("itmux.cli.get_orchestrator", side_effect=mock_get_orchestrator):
+            result = runner.invoke(main, ["add", "iTmux"])
+
+        assert result.exit_code == 1
+        assert "✗ Error:" in result.output
+        assert "iTerm2 で開いていません" in result.output
+        assert "itmux open iTmux" in result.output
+        assert "iTerm2 Error" not in result.output
+        assert "TmuxConnection" not in result.output
+
+    def test_add_tmux_detached(self):
+        """tmux セッションのみ存在する場合."""
+        runner = CliRunner()
+
+        mock_orchestrator = AsyncMock()
+        mock_orchestrator.add.side_effect = ProjectNotOpenError(
+            "iTmux", ProjectNotOpenReason.TMUX_DETACHED
+        )
+
+        async def mock_get_orchestrator():
+            return mock_orchestrator
+
+        with patch("itmux.cli.get_orchestrator", side_effect=mock_get_orchestrator):
+            result = runner.invoke(main, ["add", "iTmux"])
+
+        assert result.exit_code == 1
+        assert "tmux 上に存在しますが" in result.output
+        assert "itmux open iTmux" in result.output
+        assert "iTerm2 Error" not in result.output
+
+    def test_add_project_not_found(self):
+        """config にも tmux にも存在しない場合."""
+        runner = CliRunner()
+
+        mock_orchestrator = AsyncMock()
+        mock_orchestrator.add.side_effect = ProjectNotOpenError(
+            "iTmux", ProjectNotOpenReason.NOT_FOUND
+        )
+
+        async def mock_get_orchestrator():
+            return mock_orchestrator
+
+        with patch("itmux.cli.get_orchestrator", side_effect=mock_get_orchestrator):
+            result = runner.invoke(main, ["add", "iTmux"])
+
+        assert result.exit_code == 1
+        assert "設定に存在しません" in result.output
+        assert "itmux open iTmux" in result.output
+        assert "iTerm2 Error" not in result.output
 
 
 class TestCurrent:

--- a/tests/itmux/test_orchestrator.py
+++ b/tests/itmux/test_orchestrator.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from itmux.orchestrator import ProjectOrchestrator
 from itmux.models import WindowConfig, ProjectConfig, WindowSize
-from itmux.exceptions import ProjectNotFoundError
+from itmux.exceptions import (
+    ProjectNotFoundError,
+    ProjectNotOpenError,
+    ProjectNotOpenReason,
+    ITerm2Error,
+)
 
 
 class TestHelpers:
@@ -375,3 +380,74 @@ class TestAdd:
 
         with pytest.raises(CwdError):
             await orchestrator.add("test-project", "window-2")
+
+    @pytest.mark.asyncio
+    async def test_add_raises_when_config_exists_but_not_open(
+        self, mock_config_manager, mock_iterm2_bridge, mock_subprocess
+    ):
+        """config に存在するが iTerm2 で未オープンの場合."""
+        mock_iterm2_bridge.get_tmux_connection.side_effect = ITerm2Error(
+            "TmuxConnection not found for project: iTmux"
+        )
+        mock_subprocess.return_value = MagicMock(returncode=1)
+        mock_config_manager.get_project.return_value = ProjectConfig(
+            name="iTmux",
+            tmux_windows=[WindowConfig(name="window-1")],
+        )
+
+        orchestrator = ProjectOrchestrator(mock_config_manager, mock_iterm2_bridge)
+
+        with pytest.raises(ProjectNotOpenError) as exc_info:
+            await orchestrator.add("iTmux")
+
+        assert exc_info.value.reason is ProjectNotOpenReason.NOT_OPEN
+        assert "iTerm2 で開いていません" in str(exc_info.value)
+        assert "itmux open iTmux" in str(exc_info.value)
+        mock_iterm2_bridge.add_window.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_raises_when_tmux_session_exists_but_detached(
+        self, mock_config_manager, mock_iterm2_bridge, mock_subprocess
+    ):
+        """tmux セッションはあるが iTerm2 で未オープンの場合."""
+        mock_iterm2_bridge.get_tmux_connection.side_effect = ITerm2Error(
+            "TmuxConnection not found for project: iTmux"
+        )
+        mock_subprocess.return_value = MagicMock(returncode=0)
+        mock_config_manager.get_project.return_value = ProjectConfig(
+            name="iTmux",
+            tmux_windows=[WindowConfig(name="window-1")],
+        )
+
+        orchestrator = ProjectOrchestrator(mock_config_manager, mock_iterm2_bridge)
+
+        with pytest.raises(ProjectNotOpenError) as exc_info:
+            await orchestrator.add("iTmux")
+
+        assert exc_info.value.reason is ProjectNotOpenReason.TMUX_DETACHED
+        assert "tmux 上に存在しますが" in str(exc_info.value)
+        assert "itmux open iTmux" in str(exc_info.value)
+        mock_iterm2_bridge.add_window.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_raises_when_not_in_config_or_tmux(
+        self, mock_config_manager, mock_iterm2_bridge, mock_subprocess
+    ):
+        """config にも tmux にも存在しない場合."""
+        mock_iterm2_bridge.get_tmux_connection.side_effect = ITerm2Error(
+            "TmuxConnection not found for project: iTmux"
+        )
+        mock_subprocess.return_value = MagicMock(returncode=1)
+        mock_config_manager.get_project.side_effect = ProjectNotFoundError(
+            "Project 'iTmux' not found"
+        )
+
+        orchestrator = ProjectOrchestrator(mock_config_manager, mock_iterm2_bridge)
+
+        with pytest.raises(ProjectNotOpenError) as exc_info:
+            await orchestrator.add("iTmux")
+
+        assert exc_info.value.reason is ProjectNotOpenReason.NOT_FOUND
+        assert "設定に存在しません" in str(exc_info.value)
+        assert "itmux open iTmux" in str(exc_info.value)
+        mock_iterm2_bridge.add_window.assert_not_called()


### PR DESCRIPTION
## Summary

- `orchestrator.add()` で `bridge.add_window()` の前に iTerm2 接続を確認し、未オープン時は `ProjectNotOpenError` を送出
- config / tmux セッションの有無で 3 ケース（未オープン / デタッチ済み / 未登録）を切り分け、日本語メッセージと `itmux open <project>` への誘導を表示
- CLI で `ProjectNotOpenError` を `ITerm2Error` とは別にハンドリング（「iTerm2 Error」ラベルを付けない）

Closes #20

## 受け入れ条件

- [x] 未オープンプロジェクトへの `itmux add` で、状況に応じたユーザー向けメッセージが表示される
- [x] 「TmuxConnection not found」など内部用語がユーザー向け出力に出ない
- [x] `itmux open <project>` が案内に含まれる
- [x] config 未登録 / tmux のみ存在 / 完全未存在の切り分け
- [x] 単体テスト（`test_orchestrator.py` / `test_cli.py`）を追加

## Test plan

実施済み:
- [x] `uv run --extra dev pytest tests/itmux/test_orchestrator.py tests/itmux/test_cli.py -v`（45 passed）
- [x] `uv run --extra dev pytest -q`（133 passed）

未実施:
- [ ] 実機 iTerm2 + tmux 環境での手動確認（未オープン / デタッチ済み / 未登録の各ケース）


Made with [Cursor](https://cursor.com)